### PR TITLE
Adding new bindings to mitigate deprecation of fields in DuckDBResult when using newer DuckDB version

### DIFF
--- a/DuckDB.NET.Samples/Program.cs
+++ b/DuckDB.NET.Samples/Program.cs
@@ -132,7 +132,7 @@ namespace DuckDB.NET.Samples
                 var column = queryResult.Columns[index];
                 Console.Write($"{column.Name} ");
                 
-                Debug.Assert(column.Name == DuckDBColumnName(queryResult, index));
+                Debug.Assert(column.Name == DuckDBColumnName(queryResult, index).ToManagedString(false));
             }
 
             Console.WriteLine();

--- a/DuckDB.NET.Test/QueryTests.cs
+++ b/DuckDB.NET.Test/QueryTests.cs
@@ -1,0 +1,53 @@
+using DuckDB.NET;
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace DuckDB.NET.Test
+{
+    [TestClass]
+    public class QueryTests
+    {
+        [TestMethod]
+        public void Test()
+        {
+            var result = PlatformIndependentBindings.NativeMethods.DuckDBOpen(null, out var database);
+            result.Should().Be(DuckDBState.DuckDBSuccess);
+
+            result = PlatformIndependentBindings.NativeMethods.DuckDBConnect(database, out var connection);
+            result.Should().Be(DuckDBState.DuckDBSuccess);
+
+            using (database)
+            using (connection)
+            {
+                var table = "CREATE TABLE test(a INTEGER, b BOOLEAN);";
+                result = PlatformIndependentBindings.NativeMethods.DuckDBQuery(connection, table.ToUnmanagedString(), null);
+                result.Should().Be(DuckDBState.DuckDBSuccess);
+
+
+                var queryResult = new DuckDBResult();
+                var insert = "INSERT INTO test VALUES (1, TRUE), (2, FALSE), (3, TRUE);";
+                result = PlatformIndependentBindings.NativeMethods.DuckDBQuery(connection, insert.ToUnmanagedString(), queryResult);
+                result.Should().Be(DuckDBState.DuckDBSuccess);
+
+                var rowsChanged = PlatformIndependentBindings.NativeMethods.DuckDBRowsChanged(queryResult);
+                rowsChanged.Should().Be(3);
+
+                PlatformIndependentBindings.NativeMethods.DuckDBDestroyResult(queryResult);
+
+
+                var query = "SELECT * FROM test;";
+                result = PlatformIndependentBindings.NativeMethods.DuckDBQuery(connection, query.ToUnmanagedString(), queryResult);
+                result.Should().Be(DuckDBState.DuckDBSuccess);
+
+                var rowCount = PlatformIndependentBindings.NativeMethods.DuckDBRowCount(queryResult);
+                rowCount.Should().Be(3);
+
+                var columnCount = PlatformIndependentBindings.NativeMethods.DuckDBColumnCount(queryResult);
+                columnCount.Should().Be(2);
+
+                PlatformIndependentBindings.NativeMethods.DuckDBDestroyResult(queryResult);
+            }
+        }
+    }
+}
+

--- a/DuckDB.NET/IBindNativeMethods.cs
+++ b/DuckDB.NET/IBindNativeMethods.cs
@@ -18,6 +18,20 @@ namespace DuckDB.NET
 
         string DuckDBColumnName(DuckDBResult result, long col);
 
+        DuckDBType DuckDBColumnType(DuckDBResult result, long col);
+
+        long DuckDBColumnCount(DuckDBResult result);
+
+        long DuckDBRowCount(DuckDBResult result);
+
+        long DuckDBRowsChanged(DuckDBResult result);
+
+        IntPtr DuckDBColumnData(DuckDBResult result, long col);
+
+        IntPtr DuckDBNullmaskData(DuckDBResult result, long col);
+
+        string DuckDBResultError(DuckDBResult result);
+
         bool DuckDBValueBoolean(DuckDBResult result, long col, long row);
 
         sbyte DuckDBValueInt8(DuckDBResult result, long col, long row);

--- a/DuckDB.NET/Linux/NativeMethods.Linux.cs
+++ b/DuckDB.NET/Linux/NativeMethods.Linux.cs
@@ -37,7 +37,7 @@ namespace DuckDB.NET.Linux
 
         public string DuckDBColumnName(DuckDBResult result, long col)
         {
-            return NativeMethods.DuckDBColumnName(result, col);
+            return NativeMethods.DuckDBColumnName(result, col).ToManagedString(false);
         }
 
         public bool DuckDBValueBoolean(DuckDBResult result, long col, long row)
@@ -178,7 +178,7 @@ namespace DuckDB.NET.Linux
         public static extern void DuckDBDestroyResult([In, Out] DuckDBResult result);
 
         [DllImport(DuckDbLibrary, CallingConvention = CallingConvention.Cdecl, EntryPoint = "duckdb_column_name")]
-        public static extern string DuckDBColumnName([In, Out] DuckDBResult result, long col);
+        public static extern IntPtr DuckDBColumnName([In, Out] DuckDBResult result, long col);
 
 
         [DllImport(DuckDbLibrary, CallingConvention = CallingConvention.Cdecl, EntryPoint = "duckdb_value_boolean")]

--- a/DuckDB.NET/Linux/NativeMethods.Linux.cs
+++ b/DuckDB.NET/Linux/NativeMethods.Linux.cs
@@ -40,6 +40,41 @@ namespace DuckDB.NET.Linux
             return NativeMethods.DuckDBColumnName(result, col).ToManagedString(false);
         }
 
+        public DuckDBType DuckDBColumnType(DuckDBResult result, long col)
+        {
+            return NativeMethods.DuckDBColumnType(result, col);
+        }
+
+        public long DuckDBColumnCount(DuckDBResult result)
+        {
+            return NativeMethods.DuckDBColumnCount(result);
+        }
+
+        public long DuckDBRowCount(DuckDBResult result)
+        {
+            return NativeMethods.DuckDBRowCount(result);
+        }
+
+        public long DuckDBRowsChanged(DuckDBResult result)
+        {
+            return NativeMethods.DuckDBRowsChanged(result);
+        }
+
+        public IntPtr DuckDBColumnData(DuckDBResult result, long col)
+        {
+            return NativeMethods.DuckDBColumnData(result, col);
+        }
+
+        public IntPtr DuckDBNullmaskData(DuckDBResult result, long col)
+        {
+            return NativeMethods.DuckDBNullmaskData(result, col);
+        }
+
+        public string DuckDBResultError(DuckDBResult result)
+        {
+            return NativeMethods.DuckDBResultError(result).ToManagedString(false);
+        }
+
         public bool DuckDBValueBoolean(DuckDBResult result, long col, long row)
         {
             return NativeMethods.DuckDBValueBoolean(result, col, row);
@@ -180,6 +215,26 @@ namespace DuckDB.NET.Linux
         [DllImport(DuckDbLibrary, CallingConvention = CallingConvention.Cdecl, EntryPoint = "duckdb_column_name")]
         public static extern IntPtr DuckDBColumnName([In, Out] DuckDBResult result, long col);
 
+        [DllImport(DuckDbLibrary, CallingConvention = CallingConvention.Cdecl, EntryPoint = "duckdb_column_type")]
+        public static extern DuckDBType DuckDBColumnType(DuckDBResult result, long col);
+
+        [DllImport(DuckDbLibrary, CallingConvention = CallingConvention.Cdecl, EntryPoint = "duckdb_column_count")]
+        public static extern long DuckDBColumnCount(DuckDBResult result);
+
+        [DllImport(DuckDbLibrary, CallingConvention = CallingConvention.Cdecl, EntryPoint = "duckdb_row_count")]
+        public static extern long DuckDBRowCount(DuckDBResult result);
+
+        [DllImport(DuckDbLibrary, CallingConvention = CallingConvention.Cdecl, EntryPoint = "duckdb_rows_changed")]
+        public static extern long DuckDBRowsChanged(DuckDBResult result);
+
+        [DllImport(DuckDbLibrary, CallingConvention = CallingConvention.Cdecl, EntryPoint = "duckdb_column_data")]
+        public static extern IntPtr DuckDBColumnData(DuckDBResult result, long col);
+
+        [DllImport(DuckDbLibrary, CallingConvention = CallingConvention.Cdecl, EntryPoint = "duckdb_nullmask_data")]
+        public static extern IntPtr DuckDBNullmaskData(DuckDBResult result, long col);
+
+        [DllImport(DuckDbLibrary, CallingConvention = CallingConvention.Cdecl, EntryPoint = "duckdb_result_error")]
+        public static extern IntPtr DuckDBResultError(DuckDBResult result);
 
         [DllImport(DuckDbLibrary, CallingConvention = CallingConvention.Cdecl, EntryPoint = "duckdb_value_boolean")]
         public static extern bool DuckDBValueBoolean([In, Out] DuckDBResult result, long col, long row);

--- a/DuckDB.NET/MacOS/NativeMethods.MacOS.cs
+++ b/DuckDB.NET/MacOS/NativeMethods.MacOS.cs
@@ -37,7 +37,7 @@ namespace DuckDB.NET.MacOS
 
         public string DuckDBColumnName(DuckDBResult result, long col)
         {
-            return NativeMethods.DuckDBColumnName(result, col);
+            return NativeMethods.DuckDBColumnName(result, col).ToManagedString(false);
         }
 
         public bool DuckDBValueBoolean(DuckDBResult result, long col, long row)
@@ -178,7 +178,7 @@ namespace DuckDB.NET.MacOS
         public static extern void DuckDBDestroyResult([In, Out] DuckDBResult result);
 
         [DllImport(DuckDbLibrary, CallingConvention = CallingConvention.Cdecl, EntryPoint = "duckdb_column_name")]
-        public static extern string DuckDBColumnName([In, Out] DuckDBResult result, long col);
+        public static extern IntPtr DuckDBColumnName([In, Out] DuckDBResult result, long col);
 
 
         [DllImport(DuckDbLibrary, CallingConvention = CallingConvention.Cdecl, EntryPoint = "duckdb_value_boolean")]

--- a/DuckDB.NET/MacOS/NativeMethods.MacOS.cs
+++ b/DuckDB.NET/MacOS/NativeMethods.MacOS.cs
@@ -40,6 +40,41 @@ namespace DuckDB.NET.MacOS
             return NativeMethods.DuckDBColumnName(result, col).ToManagedString(false);
         }
 
+        public DuckDBType DuckDBColumnType(DuckDBResult result, long col)
+        {
+            return NativeMethods.DuckDBColumnType(result, col);
+        }
+
+        public long DuckDBColumnCount(DuckDBResult result)
+        {
+            return NativeMethods.DuckDBColumnCount(result);
+        }
+
+        public long DuckDBRowCount(DuckDBResult result)
+        {
+            return NativeMethods.DuckDBRowCount(result);
+        }
+
+        public long DuckDBRowsChanged(DuckDBResult result)
+        {
+            return NativeMethods.DuckDBRowsChanged(result);
+        }
+
+        public IntPtr DuckDBColumnData(DuckDBResult result, long col)
+        {
+            return NativeMethods.DuckDBColumnData(result, col);
+        }
+
+        public IntPtr DuckDBNullmaskData(DuckDBResult result, long col)
+        {
+            return NativeMethods.DuckDBNullmaskData(result, col);
+        }
+
+        public string DuckDBResultError(DuckDBResult result)
+        {
+            return NativeMethods.DuckDBResultError(result).ToManagedString(false);
+        }
+
         public bool DuckDBValueBoolean(DuckDBResult result, long col, long row)
         {
             return NativeMethods.DuckDBValueBoolean(result, col, row);
@@ -180,6 +215,26 @@ namespace DuckDB.NET.MacOS
         [DllImport(DuckDbLibrary, CallingConvention = CallingConvention.Cdecl, EntryPoint = "duckdb_column_name")]
         public static extern IntPtr DuckDBColumnName([In, Out] DuckDBResult result, long col);
 
+        [DllImport(DuckDbLibrary, CallingConvention = CallingConvention.Cdecl, EntryPoint = "duckdb_column_type")]
+        public static extern DuckDBType DuckDBColumnType(DuckDBResult result, long col);
+
+        [DllImport(DuckDbLibrary, CallingConvention = CallingConvention.Cdecl, EntryPoint = "duckdb_column_count")]
+        public static extern long DuckDBColumnCount(DuckDBResult result);
+
+        [DllImport(DuckDbLibrary, CallingConvention = CallingConvention.Cdecl, EntryPoint = "duckdb_row_count")]
+        public static extern long DuckDBRowCount(DuckDBResult result);
+
+        [DllImport(DuckDbLibrary, CallingConvention = CallingConvention.Cdecl, EntryPoint = "duckdb_rows_changed")]
+        public static extern long DuckDBRowsChanged(DuckDBResult result);
+
+        [DllImport(DuckDbLibrary, CallingConvention = CallingConvention.Cdecl, EntryPoint = "duckdb_column_data")]
+        public static extern IntPtr DuckDBColumnData(DuckDBResult result, long col);
+
+        [DllImport(DuckDbLibrary, CallingConvention = CallingConvention.Cdecl, EntryPoint = "duckdb_nullmask_data")]
+        public static extern IntPtr DuckDBNullmaskData(DuckDBResult result, long col);
+
+        [DllImport(DuckDbLibrary, CallingConvention = CallingConvention.Cdecl, EntryPoint = "duckdb_result_error")]
+        public static extern IntPtr DuckDBResultError(DuckDBResult result);
 
         [DllImport(DuckDbLibrary, CallingConvention = CallingConvention.Cdecl, EntryPoint = "duckdb_value_boolean")]
         public static extern bool DuckDBValueBoolean([In, Out] DuckDBResult result, long col, long row);

--- a/DuckDB.NET/Windows/NativeMethods.Windows.cs
+++ b/DuckDB.NET/Windows/NativeMethods.Windows.cs
@@ -40,6 +40,41 @@ namespace DuckDB.NET.Windows
             return NativeMethods.DuckDBColumnName(result, col).ToManagedString(false);
         }
 
+        public DuckDBType DuckDBColumnType(DuckDBResult result, long col)
+        {
+            return NativeMethods.DuckDBColumnType(result, col);
+        }
+
+        public long DuckDBColumnCount(DuckDBResult result)
+        {
+            return NativeMethods.DuckDBColumnCount(result);
+        }
+
+        public long DuckDBRowCount(DuckDBResult result)
+        {
+            return NativeMethods.DuckDBRowCount(result);
+        }
+
+        public long DuckDBRowsChanged(DuckDBResult result)
+        {
+            return NativeMethods.DuckDBRowsChanged(result);
+        }
+
+        public IntPtr DuckDBColumnData(DuckDBResult result, long col)
+        {
+            return NativeMethods.DuckDBColumnData(result, col);
+        }
+
+        public IntPtr DuckDBNullmaskData(DuckDBResult result, long col)
+        {
+            return NativeMethods.DuckDBNullmaskData(result, col);
+        }
+
+        public string DuckDBResultError(DuckDBResult result)
+        {
+            return NativeMethods.DuckDBResultError(result).ToManagedString(false);
+        }
+
         public bool DuckDBValueBoolean(DuckDBResult result, long col, long row)
         {
             return NativeMethods.DuckDBValueBoolean(result, col, row);
@@ -179,6 +214,27 @@ namespace DuckDB.NET.Windows
 
         [DllImport(DuckDbLibrary, CallingConvention = CallingConvention.Cdecl, EntryPoint = "duckdb_column_name")]
         public static extern IntPtr DuckDBColumnName([In, Out] DuckDBResult result, long col);
+
+        [DllImport(DuckDbLibrary, CallingConvention = CallingConvention.Cdecl, EntryPoint = "duckdb_column_type")]
+        public static extern DuckDBType DuckDBColumnType(DuckDBResult result, long col);
+
+        [DllImport(DuckDbLibrary, CallingConvention = CallingConvention.Cdecl, EntryPoint = "duckdb_column_count")]
+        public static extern long DuckDBColumnCount(DuckDBResult result);
+
+        [DllImport(DuckDbLibrary, CallingConvention = CallingConvention.Cdecl, EntryPoint = "duckdb_row_count")]
+        public static extern long DuckDBRowCount(DuckDBResult result);
+
+        [DllImport(DuckDbLibrary, CallingConvention = CallingConvention.Cdecl, EntryPoint = "duckdb_rows_changed")]
+        public static extern long DuckDBRowsChanged(DuckDBResult result);
+
+        [DllImport(DuckDbLibrary, CallingConvention = CallingConvention.Cdecl, EntryPoint = "duckdb_column_data")]
+        public static extern IntPtr DuckDBColumnData(DuckDBResult result, long col);
+
+        [DllImport(DuckDbLibrary, CallingConvention = CallingConvention.Cdecl, EntryPoint = "duckdb_nullmask_data")]
+        public static extern IntPtr DuckDBNullmaskData(DuckDBResult result, long col);
+
+        [DllImport(DuckDbLibrary, CallingConvention = CallingConvention.Cdecl, EntryPoint = "duckdb_result_error")]
+        public static extern IntPtr DuckDBResultError(DuckDBResult result);
 
         [DllImport(DuckDbLibrary, CallingConvention = CallingConvention.Cdecl, EntryPoint = "duckdb_value_boolean")]
         public static extern bool DuckDBValueBoolean([In, Out] DuckDBResult result, long col, long row);

--- a/DuckDB.NET/Windows/NativeMethods.Windows.cs
+++ b/DuckDB.NET/Windows/NativeMethods.Windows.cs
@@ -37,7 +37,7 @@ namespace DuckDB.NET.Windows
 
         public string DuckDBColumnName(DuckDBResult result, long col)
         {
-            return NativeMethods.DuckDBColumnName(result, col);
+            return NativeMethods.DuckDBColumnName(result, col).ToManagedString(false);
         }
 
         public bool DuckDBValueBoolean(DuckDBResult result, long col, long row)
@@ -178,7 +178,7 @@ namespace DuckDB.NET.Windows
         public static extern void DuckDBDestroyResult([In, Out] DuckDBResult result);
 
         [DllImport(DuckDbLibrary, CallingConvention = CallingConvention.Cdecl, EntryPoint = "duckdb_column_name")]
-        public static extern string DuckDBColumnName([In, Out] DuckDBResult result, long col);
+        public static extern IntPtr DuckDBColumnName([In, Out] DuckDBResult result, long col);
 
         [DllImport(DuckDbLibrary, CallingConvention = CallingConvention.Cdecl, EntryPoint = "duckdb_value_boolean")]
         public static extern bool DuckDBValueBoolean([In, Out] DuckDBResult result, long col, long row);


### PR DESCRIPTION
Hi

I ran into issue #25 and I set it upon myself to try to fix it and here is the result. 

I've mitigated the issues by adding the new bindings recommended in the header file [duckdb.h](https://github.com/duckdb/duckdb/blob/master/src/include/duckdb.h). I've also added a comment above the deprecated fields in DuckDBResult.

I'm a little uncertain if all functionality in the ADO layer is still functioning as it was before. This could probably be tested a bit more thoroughly.

I've marked the deprecated fields in DuckDBResult as private and I removed DuckDBColumn since it isn't really used anymore (except for maybe legacy usages)?
 
Feedback is welcome.
