### PR TITLE
Move Utils to bindings project

### DIFF
--- a/DuckDB.NET/Utils.cs
+++ b/DuckDB.NET/Utils.cs
@@ -2,16 +2,16 @@
 using System.Runtime.InteropServices;
 using System.Text;
 
-namespace DuckDB.NET.Data.Internal
+namespace DuckDB.NET
 {
-    static class Utils
+    public static class Utils
     {
-        internal static bool IsSuccess(this DuckDBState duckDBState)
+        public static bool IsSuccess(this DuckDBState duckDBState)
         {
             return duckDBState == DuckDBState.DuckDBSuccess;
         }
 
-        internal static string ToManagedString(this IntPtr unmanagedString)
+        public static string ToManagedString(this IntPtr unmanagedString)
         {
             if (unmanagedString == IntPtr.Zero)
             {
@@ -39,7 +39,7 @@ namespace DuckDB.NET.Data.Internal
             return Encoding.UTF8.GetString(byteArray, 0, length);
         }
 
-        internal static SafeUnmanagedMemoryHandle ToUnmanagedString(this string managedString)
+        public static SafeUnmanagedMemoryHandle ToUnmanagedString(this string managedString)
         {
             int len = Encoding.UTF8.GetByteCount(managedString);
 

--- a/DuckDB.NET/Utils.cs
+++ b/DuckDB.NET/Utils.cs
@@ -11,7 +11,7 @@ namespace DuckDB.NET
             return duckDBState == DuckDBState.DuckDBSuccess;
         }
 
-        public static string ToManagedString(this IntPtr unmanagedString)
+        public static string ToManagedString(this IntPtr unmanagedString, bool freeWhenCopied = true)
         {
             if (unmanagedString == IntPtr.Zero)
             {
@@ -34,7 +34,10 @@ namespace DuckDB.NET
 
             Marshal.Copy(unmanagedString, byteArray, 0, length);
 
-            PlatformIndependentBindings.NativeMethods.DuckDBFree(unmanagedString);
+            if (freeWhenCopied)
+            {
+                PlatformIndependentBindings.NativeMethods.DuckDBFree(unmanagedString);
+            }
 
             return Encoding.UTF8.GetString(byteArray, 0, length);
         }


### PR DESCRIPTION
This is a pull request to move the Utils class to the bindings project. Eventually I want to use some of these Utils in some of the bindings (e.g. ToManagedString). I have added a flag, so one is able to disable the 'free' call after the string has been copied. Mainly because calls to duckdb_column_name and duckdb_result_error returns a const char* that is cleaned up when duckdb_destroy_result is called and shouldn't be freed by duckdb_free.