### PR TITLE
Convert DuckDBResult to class to benefit from reference semantics.

### DIFF
--- a/DuckDB.NET.Data/DuckDBCommand.cs
+++ b/DuckDB.NET.Data/DuckDBCommand.cs
@@ -42,8 +42,8 @@ namespace DuckDB.NET.Data
         private int ExecuteScalarOrNonQuery()
         {
             using var unmanagedString = CommandText.ToUnmanagedString();
-            
-            var result = PlatformIndependentBindings.NativeMethods.DuckDBQuery(connection.NativeConnection, unmanagedString, out var queryResult);
+            var queryResult = new DuckDBResult();
+            var result = PlatformIndependentBindings.NativeMethods.DuckDBQuery(connection.NativeConnection, unmanagedString, queryResult);
 
             if (!string.IsNullOrEmpty(queryResult.ErrorMessage))
             {

--- a/DuckDB.NET.Data/DuckDBDataReader.cs
+++ b/DuckDB.NET.Data/DuckDBDataReader.cs
@@ -27,7 +27,8 @@ namespace DuckDB.NET.Data
             this.behavior = behavior;
 
             using var unmanagedString = command.CommandText.ToUnmanagedString();
-            var state = PlatformIndependentBindings.NativeMethods.DuckDBQuery(command.DBNativeConnection, unmanagedString, out queryResult);
+            queryResult = new DuckDBResult();
+            var state = PlatformIndependentBindings.NativeMethods.DuckDBQuery(command.DBNativeConnection, unmanagedString, queryResult);
             
             if (!string.IsNullOrEmpty(queryResult.ErrorMessage))
             {
@@ -227,7 +228,7 @@ namespace DuckDB.NET.Data
 
         public override void Close()
         {
-            PlatformIndependentBindings.NativeMethods.DuckDBDestroyResult(ref queryResult);
+            PlatformIndependentBindings.NativeMethods.DuckDBDestroyResult(queryResult);
 
             if (behavior == CommandBehavior.CloseConnection)
             {

--- a/DuckDB.NET.Samples/Program.cs
+++ b/DuckDB.NET.Samples/Program.cs
@@ -64,11 +64,15 @@ namespace DuckDB.NET.Samples
                 result = DuckDBConnect(database, out var connection);
                 using (connection)
                 {
-                    result = DuckDBQuery(connection, "CREATE TABLE integers(foo INTEGER, bar INTEGER);", out var queryResult);
-                    result = DuckDBQuery(connection, "INSERT INTO integers VALUES (3, 4), (5, 6), (7, NULL);", out queryResult);
-                    result = DuckDBQuery(connection, "SELECT foo, bar FROM integers", out queryResult);
+                    var queryResult = new DuckDBResult();
+                    result = DuckDBQuery(connection, "CREATE TABLE integers(foo INTEGER, bar INTEGER);", null);
+                    result = DuckDBQuery(connection, "INSERT INTO integers VALUES (3, 4), (5, 6), (7, NULL);", null);
+                    result = DuckDBQuery(connection, "SELECT foo, bar FROM integers", queryResult);
 
                     PrintQueryResults(queryResult);
+
+                    // clean up
+                    DuckDBDestroyResult(queryResult);
 
                     result = DuckDBPrepare(connection, "INSERT INTO integers VALUES (?, ?)", out var insertStatement);
 
@@ -77,7 +81,7 @@ namespace DuckDB.NET.Samples
                         result = DuckDBBindInt32(insertStatement, 1, 42); // the parameter index starts counting at 1!
                         result = DuckDBBindInt32(insertStatement, 2, 43);
 
-                        result = DuckDBExecutePrepared(insertStatement, out var _);
+                        result = DuckDBExecutePrepared(insertStatement, null);
                     }
 
 
@@ -87,13 +91,13 @@ namespace DuckDB.NET.Samples
                     {
                         result = DuckDBBindInt32(selectStatement, 1, 42);
 
-                        result = DuckDBExecutePrepared(selectStatement, out queryResult);
+                        result = DuckDBExecutePrepared(selectStatement, queryResult);
                     }
 
                     PrintQueryResults(queryResult);
 
                     // clean up
-                    DuckDBDestroyResult(out queryResult);
+                    DuckDBDestroyResult(queryResult);
                 }
             }
         }

--- a/DuckDB.NET/DuckDBNativeObjects.cs
+++ b/DuckDB.NET/DuckDBNativeObjects.cs
@@ -71,7 +71,7 @@ namespace DuckDB.NET
     }
 
     [StructLayout(LayoutKind.Sequential)]
-    public struct DuckDBResult
+    public class DuckDBResult
     {
         public long ColumnCount { get; }
         public long RowCount { get; }

--- a/DuckDB.NET/IBindNativeMethods.cs
+++ b/DuckDB.NET/IBindNativeMethods.cs
@@ -12,9 +12,9 @@ namespace DuckDB.NET
 
         void DuckDBDisconnect(out IntPtr connection);
 
-        DuckDBState DuckDBQuery(DuckDBNativeConnection connection, SafeUnmanagedMemoryHandle query, out DuckDBResult result);
+        DuckDBState DuckDBQuery(DuckDBNativeConnection connection, SafeUnmanagedMemoryHandle query, DuckDBResult result);
 
-        void DuckDBDestroyResult(ref DuckDBResult result);
+        void DuckDBDestroyResult(DuckDBResult result);
 
         string DuckDBColumnName(DuckDBResult result, long col);
 
@@ -56,7 +56,7 @@ namespace DuckDB.NET
 
         DuckDBState DuckDBBindNull(DuckDBPreparedStatement preparedStatement, long index);
 
-        DuckDBState DuckDBExecutePrepared(DuckDBPreparedStatement preparedStatement, out DuckDBResult result);
+        DuckDBState DuckDBExecutePrepared(DuckDBPreparedStatement preparedStatement, DuckDBResult result);
 
         void DuckDBDestroyPrepare(out IntPtr preparedStatement);
 

--- a/DuckDB.NET/Linux/NativeMethods.Linux.cs
+++ b/DuckDB.NET/Linux/NativeMethods.Linux.cs
@@ -25,59 +25,59 @@ namespace DuckDB.NET.Linux
             NativeMethods.DuckDBDisconnect(out connection);
         }
 
-        public DuckDBState DuckDBQuery(DuckDBNativeConnection connection, SafeUnmanagedMemoryHandle query, out DuckDBResult result)
+        public DuckDBState DuckDBQuery(DuckDBNativeConnection connection, SafeUnmanagedMemoryHandle query, DuckDBResult result)
         {
-            return NativeMethods.DuckDBQuery(connection, query, out result);
+            return NativeMethods.DuckDBQuery(connection, query, result);
         }
 
-        public void DuckDBDestroyResult(ref DuckDBResult result)
+        public void DuckDBDestroyResult(DuckDBResult result)
         {
-            NativeMethods.DuckDBDestroyResult(ref result);
+            NativeMethods.DuckDBDestroyResult(result);
         }
 
         public string DuckDBColumnName(DuckDBResult result, long col)
         {
-            return NativeMethods.DuckDBColumnName(ref result, col);
+            return NativeMethods.DuckDBColumnName(result, col);
         }
 
         public bool DuckDBValueBoolean(DuckDBResult result, long col, long row)
         {
-            return NativeMethods.DuckDBValueBoolean(ref result, col, row);
+            return NativeMethods.DuckDBValueBoolean(result, col, row);
         }
 
         public sbyte DuckDBValueInt8(DuckDBResult result, long col, long row)
         {
-            return NativeMethods.DuckDBValueInt8(ref result, col, row);
+            return NativeMethods.DuckDBValueInt8(result, col, row);
         }
 
         public short DuckDBValueInt16(DuckDBResult result, long col, long row)
         {
-            return NativeMethods.DuckDBValueInt16(ref result, col, row);
+            return NativeMethods.DuckDBValueInt16(result, col, row);
         }
 
         public int DuckDBValueInt32(DuckDBResult result, long col, long row)
         {
-            return NativeMethods.DuckDBValueInt32(ref result, col, row);
+            return NativeMethods.DuckDBValueInt32(result, col, row);
         }
 
         public long DuckDBValueInt64(DuckDBResult result, long col, long row)
         {
-            return NativeMethods.DuckDBValueInt64(ref result, col, row);
+            return NativeMethods.DuckDBValueInt64(result, col, row);
         }
 
         public float DuckDBValueFloat(DuckDBResult result, long col, long row)
         {
-            return NativeMethods.DuckDBValueFloat(ref result, col, row);
+            return NativeMethods.DuckDBValueFloat(result, col, row);
         }
 
         public double DuckDBValueDouble(DuckDBResult result, long col, long row)
         {
-            return NativeMethods.DuckDBValueDouble(ref result, col, row);
+            return NativeMethods.DuckDBValueDouble(result, col, row);
         }
 
         public IntPtr DuckDBValueVarchar(DuckDBResult result, long col, long row)
         {
-            return NativeMethods.DuckDBValueVarchar(ref result, col, row);
+            return NativeMethods.DuckDBValueVarchar(result, col, row);
         }
 
         public DuckDBState DuckDBPrepare(DuckDBNativeConnection connection, string query, out DuckDBPreparedStatement preparedStatement)
@@ -135,9 +135,9 @@ namespace DuckDB.NET.Linux
             return NativeMethods.DuckDBBindNull(preparedStatement, index);
         }
 
-        public DuckDBState DuckDBExecutePrepared(DuckDBPreparedStatement preparedStatement, out DuckDBResult result)
+        public DuckDBState DuckDBExecutePrepared(DuckDBPreparedStatement preparedStatement, DuckDBResult result)
         {
-            return NativeMethods.DuckDBExecutePrepared(preparedStatement, out result);
+            return NativeMethods.DuckDBExecutePrepared(preparedStatement, result);
         }
 
         public void DuckDBDestroyPrepare(out IntPtr preparedStatement)
@@ -169,41 +169,41 @@ namespace DuckDB.NET.Linux
         public static extern void DuckDBDisconnect(out IntPtr connection);
 
         [DllImport(DuckDbLibrary, CallingConvention = CallingConvention.Cdecl, EntryPoint = "duckdb_query")]
-        public static extern DuckDBState DuckDBQuery(DuckDBNativeConnection connection, string query, out DuckDBResult result);
+        public static extern DuckDBState DuckDBQuery(DuckDBNativeConnection connection, string query, [In, Out] DuckDBResult result);
 
         [DllImport(DuckDbLibrary, CallingConvention = CallingConvention.Cdecl, EntryPoint = "duckdb_query")]
-        public static extern DuckDBState DuckDBQuery(DuckDBNativeConnection connection, SafeUnmanagedMemoryHandle query, out DuckDBResult result);
+        public static extern DuckDBState DuckDBQuery(DuckDBNativeConnection connection, SafeUnmanagedMemoryHandle query, [In, Out] DuckDBResult result);
 
         [DllImport(DuckDbLibrary, CallingConvention = CallingConvention.Cdecl, EntryPoint = "duckdb_destroy_result")]
-        public static extern void DuckDBDestroyResult(ref DuckDBResult result);
+        public static extern void DuckDBDestroyResult([In, Out] DuckDBResult result);
 
         [DllImport(DuckDbLibrary, CallingConvention = CallingConvention.Cdecl, EntryPoint = "duckdb_column_name")]
-        public static extern string DuckDBColumnName(ref DuckDBResult result, long col);
+        public static extern string DuckDBColumnName([In, Out] DuckDBResult result, long col);
 
 
         [DllImport(DuckDbLibrary, CallingConvention = CallingConvention.Cdecl, EntryPoint = "duckdb_value_boolean")]
-        public static extern bool DuckDBValueBoolean(ref DuckDBResult result, long col, long row);
+        public static extern bool DuckDBValueBoolean([In, Out] DuckDBResult result, long col, long row);
 
         [DllImport(DuckDbLibrary, CallingConvention = CallingConvention.Cdecl, EntryPoint = "duckdb_value_int8")]
-        public static extern sbyte DuckDBValueInt8(ref DuckDBResult result, long col, long row);
+        public static extern sbyte DuckDBValueInt8([In, Out] DuckDBResult result, long col, long row);
 
         [DllImport(DuckDbLibrary, CallingConvention = CallingConvention.Cdecl, EntryPoint = "duckdb_value_int16")]
-        public static extern short DuckDBValueInt16(ref DuckDBResult result, long col, long row);
+        public static extern short DuckDBValueInt16([In, Out] DuckDBResult result, long col, long row);
 
         [DllImport(DuckDbLibrary, CallingConvention = CallingConvention.Cdecl, EntryPoint = "duckdb_value_int32")]
-        public static extern int DuckDBValueInt32(ref DuckDBResult result, long col, long row);
+        public static extern int DuckDBValueInt32([In, Out] DuckDBResult result, long col, long row);
 
         [DllImport(DuckDbLibrary, CallingConvention = CallingConvention.Cdecl, EntryPoint = "duckdb_value_int64")]
-        public static extern long DuckDBValueInt64(ref DuckDBResult result, long col, long row);
+        public static extern long DuckDBValueInt64([In, Out] DuckDBResult result, long col, long row);
 
         [DllImport(DuckDbLibrary, CallingConvention = CallingConvention.Cdecl, EntryPoint = "duckdb_value_float")]
-        public static extern float DuckDBValueFloat(ref DuckDBResult result, long col, long row);
+        public static extern float DuckDBValueFloat([In, Out] DuckDBResult result, long col, long row);
 
         [DllImport(DuckDbLibrary, CallingConvention = CallingConvention.Cdecl, EntryPoint = "duckdb_value_double")]
-        public static extern double DuckDBValueDouble(ref DuckDBResult result, long col, long row);
+        public static extern double DuckDBValueDouble([In, Out] DuckDBResult result, long col, long row);
 
         [DllImport(DuckDbLibrary, CallingConvention = CallingConvention.Cdecl, EntryPoint = "duckdb_value_varchar")]
-        public static extern IntPtr DuckDBValueVarchar(ref DuckDBResult result, long col, long row);
+        public static extern IntPtr DuckDBValueVarchar([In, Out] DuckDBResult result, long col, long row);
 
         [DllImport(DuckDbLibrary, CallingConvention = CallingConvention.Cdecl, EntryPoint = "duckdb_prepare")]
         public static extern DuckDBState DuckDBPrepare(DuckDBNativeConnection connection, string query, out DuckDBPreparedStatement preparedStatement);
@@ -239,7 +239,7 @@ namespace DuckDB.NET.Linux
         public static extern DuckDBState DuckDBBindNull(DuckDBPreparedStatement preparedStatement, long index);
 
         [DllImport(DuckDbLibrary, CallingConvention = CallingConvention.Cdecl, EntryPoint = "duckdb_execute_prepared")]
-        public static extern DuckDBState DuckDBExecutePrepared(DuckDBPreparedStatement preparedStatement, out DuckDBResult result);
+        public static extern DuckDBState DuckDBExecutePrepared(DuckDBPreparedStatement preparedStatement, [In, Out] DuckDBResult result);
 
         [DllImport(DuckDbLibrary, CallingConvention = CallingConvention.Cdecl, EntryPoint = "duckdb_destroy_prepare")]
         public static extern void DuckDBDestroyPrepare(out IntPtr preparedStatement);

--- a/DuckDB.NET/MacOS/NativeMethods.MacOS.cs
+++ b/DuckDB.NET/MacOS/NativeMethods.MacOS.cs
@@ -25,14 +25,14 @@ namespace DuckDB.NET.MacOS
             NativeMethods.DuckDBDisconnect(out connection);
         }
 
-        public DuckDBState DuckDBQuery(DuckDBNativeConnection connection, SafeUnmanagedMemoryHandle query, out DuckDBResult result)
+        public DuckDBState DuckDBQuery(DuckDBNativeConnection connection, SafeUnmanagedMemoryHandle query, DuckDBResult result)
         {
-            return NativeMethods.DuckDBQuery(connection, query, out result);
+            return NativeMethods.DuckDBQuery(connection, query, result);
         }
 
-        public void DuckDBDestroyResult(ref DuckDBResult result)
+        public void DuckDBDestroyResult(DuckDBResult result)
         {
-            NativeMethods.DuckDBDestroyResult(ref result);
+            NativeMethods.DuckDBDestroyResult(result);
         }
 
         public string DuckDBColumnName(DuckDBResult result, long col)
@@ -135,9 +135,9 @@ namespace DuckDB.NET.MacOS
             return NativeMethods.DuckDBBindNull(preparedStatement, index);
         }
 
-        public DuckDBState DuckDBExecutePrepared(DuckDBPreparedStatement preparedStatement, out DuckDBResult result)
+        public DuckDBState DuckDBExecutePrepared(DuckDBPreparedStatement preparedStatement, DuckDBResult result)
         {
-            return NativeMethods.DuckDBExecutePrepared(preparedStatement, out result);
+            return NativeMethods.DuckDBExecutePrepared(preparedStatement, result);
         }
 
         public void DuckDBDestroyPrepare(out IntPtr preparedStatement)
@@ -169,41 +169,41 @@ namespace DuckDB.NET.MacOS
         public static extern void DuckDBDisconnect(out IntPtr connection);
         
         [DllImport(DuckDbLibrary, CallingConvention = CallingConvention.Cdecl, EntryPoint = "duckdb_query")]
-        public static extern DuckDBState DuckDBQuery(DuckDBNativeConnection connection, string query, out DuckDBResult result);
+        public static extern DuckDBState DuckDBQuery(DuckDBNativeConnection connection, string query, [In, Out] DuckDBResult result);
 
         [DllImport(DuckDbLibrary, CallingConvention = CallingConvention.Cdecl, EntryPoint = "duckdb_query")]
-        public static extern DuckDBState DuckDBQuery(DuckDBNativeConnection connection, SafeUnmanagedMemoryHandle query, out DuckDBResult result);
+        public static extern DuckDBState DuckDBQuery(DuckDBNativeConnection connection, SafeUnmanagedMemoryHandle query, [In, Out] DuckDBResult result);
 
         [DllImport(DuckDbLibrary, CallingConvention = CallingConvention.Cdecl, EntryPoint = "duckdb_destroy_result")]
-        public static extern void DuckDBDestroyResult(ref DuckDBResult result);
+        public static extern void DuckDBDestroyResult([In, Out] DuckDBResult result);
 
         [DllImport(DuckDbLibrary, CallingConvention = CallingConvention.Cdecl, EntryPoint = "duckdb_column_name")]
-        public static extern string DuckDBColumnName(DuckDBResult result, long col);
+        public static extern string DuckDBColumnName([In, Out] DuckDBResult result, long col);
 
 
         [DllImport(DuckDbLibrary, CallingConvention = CallingConvention.Cdecl, EntryPoint = "duckdb_value_boolean")]
-        public static extern bool DuckDBValueBoolean(DuckDBResult result, long col, long row);
+        public static extern bool DuckDBValueBoolean([In, Out] DuckDBResult result, long col, long row);
 
         [DllImport(DuckDbLibrary, CallingConvention = CallingConvention.Cdecl, EntryPoint = "duckdb_value_int8")]
-        public static extern sbyte DuckDBValueInt8(DuckDBResult result, long col, long row);
+        public static extern sbyte DuckDBValueInt8([In, Out] DuckDBResult result, long col, long row);
 
         [DllImport(DuckDbLibrary, CallingConvention = CallingConvention.Cdecl, EntryPoint = "duckdb_value_int16")]
-        public static extern short DuckDBValueInt16(DuckDBResult result, long col, long row);
+        public static extern short DuckDBValueInt16([In, Out] DuckDBResult result, long col, long row);
 
         [DllImport(DuckDbLibrary, CallingConvention = CallingConvention.Cdecl, EntryPoint = "duckdb_value_int32")]
-        public static extern int DuckDBValueInt32(DuckDBResult result, long col, long row);
+        public static extern int DuckDBValueInt32([In, Out] DuckDBResult result, long col, long row);
 
         [DllImport(DuckDbLibrary, CallingConvention = CallingConvention.Cdecl, EntryPoint = "duckdb_value_int64")]
-        public static extern long DuckDBValueInt64(DuckDBResult result, long col, long row);
+        public static extern long DuckDBValueInt64([In, Out] DuckDBResult result, long col, long row);
 
         [DllImport(DuckDbLibrary, CallingConvention = CallingConvention.Cdecl, EntryPoint = "duckdb_value_float")]
-        public static extern float DuckDBValueFloat(DuckDBResult result, long col, long row);
+        public static extern float DuckDBValueFloat([In, Out] DuckDBResult result, long col, long row);
 
         [DllImport(DuckDbLibrary, CallingConvention = CallingConvention.Cdecl, EntryPoint = "duckdb_value_double")]
-        public static extern double DuckDBValueDouble(DuckDBResult result, long col, long row);
+        public static extern double DuckDBValueDouble([In, Out] DuckDBResult result, long col, long row);
 
         [DllImport(DuckDbLibrary, CallingConvention = CallingConvention.Cdecl, EntryPoint = "duckdb_value_varchar")]
-        public static extern IntPtr DuckDBValueVarchar(DuckDBResult result, long col, long row);
+        public static extern IntPtr DuckDBValueVarchar([In, Out] DuckDBResult result, long col, long row);
         
         [DllImport(DuckDbLibrary, CallingConvention = CallingConvention.Cdecl, EntryPoint = "duckdb_prepare")]
         public static extern DuckDBState DuckDBPrepare(DuckDBNativeConnection connection, string query, out DuckDBPreparedStatement preparedStatement);
@@ -239,7 +239,7 @@ namespace DuckDB.NET.MacOS
         public static extern DuckDBState DuckDBBindNull(DuckDBPreparedStatement preparedStatement, long index);
 
         [DllImport(DuckDbLibrary, CallingConvention = CallingConvention.Cdecl, EntryPoint = "duckdb_execute_prepared")]
-        public static extern DuckDBState DuckDBExecutePrepared(DuckDBPreparedStatement preparedStatement, out DuckDBResult result);
+        public static extern DuckDBState DuckDBExecutePrepared(DuckDBPreparedStatement preparedStatement, [In, Out] DuckDBResult result);
 
         [DllImport(DuckDbLibrary, CallingConvention = CallingConvention.Cdecl, EntryPoint = "duckdb_destroy_prepare")]
         public static extern void DuckDBDestroyPrepare(out IntPtr preparedStatement);

--- a/DuckDB.NET/Windows/NativeMethods.Windows.cs
+++ b/DuckDB.NET/Windows/NativeMethods.Windows.cs
@@ -25,14 +25,14 @@ namespace DuckDB.NET.Windows
             NativeMethods.DuckDBDisconnect(out connection);
         }
 
-        public DuckDBState DuckDBQuery(DuckDBNativeConnection connection, SafeUnmanagedMemoryHandle query, out DuckDBResult result)
+        public DuckDBState DuckDBQuery(DuckDBNativeConnection connection, SafeUnmanagedMemoryHandle query, DuckDBResult result)
         {
-            return NativeMethods.DuckDBQuery(connection, query, out result);
+            return NativeMethods.DuckDBQuery(connection, query, result);
         }
 
-        public void DuckDBDestroyResult(ref DuckDBResult result)
+        public void DuckDBDestroyResult(DuckDBResult result)
         {
-            NativeMethods.DuckDBDestroyResult(ref result);
+            NativeMethods.DuckDBDestroyResult(result);
         }
 
         public string DuckDBColumnName(DuckDBResult result, long col)
@@ -135,9 +135,9 @@ namespace DuckDB.NET.Windows
             return NativeMethods.DuckDBBindNull(preparedStatement, index);
         }
 
-        public DuckDBState DuckDBExecutePrepared(DuckDBPreparedStatement preparedStatement, out DuckDBResult result)
+        public DuckDBState DuckDBExecutePrepared(DuckDBPreparedStatement preparedStatement, DuckDBResult result)
         {
-            return NativeMethods.DuckDBExecutePrepared(preparedStatement, out result);
+            return NativeMethods.DuckDBExecutePrepared(preparedStatement, result);
         }
 
         public void DuckDBDestroyPrepare(out IntPtr preparedStatement)
@@ -169,40 +169,40 @@ namespace DuckDB.NET.Windows
         public static extern void DuckDBDisconnect(out IntPtr connection);
 
         [DllImport(DuckDbLibrary, CallingConvention = CallingConvention.Cdecl, EntryPoint = "duckdb_query")]
-        public static extern DuckDBState DuckDBQuery(DuckDBNativeConnection connection, string query, out DuckDBResult result);
+        public static extern DuckDBState DuckDBQuery(DuckDBNativeConnection connection, string query, [In, Out] DuckDBResult result);
 
         [DllImport(DuckDbLibrary, CallingConvention = CallingConvention.Cdecl, EntryPoint = "duckdb_query")]
-        public static extern DuckDBState DuckDBQuery(DuckDBNativeConnection connection, SafeUnmanagedMemoryHandle query, out DuckDBResult result);
+        public static extern DuckDBState DuckDBQuery(DuckDBNativeConnection connection, SafeUnmanagedMemoryHandle query, [In, Out] DuckDBResult result);
 
         [DllImport(DuckDbLibrary, CallingConvention = CallingConvention.Cdecl, EntryPoint = "duckdb_destroy_result")]
-        public static extern void DuckDBDestroyResult(ref DuckDBResult result);
+        public static extern void DuckDBDestroyResult([In, Out] DuckDBResult result);
 
         [DllImport(DuckDbLibrary, CallingConvention = CallingConvention.Cdecl, EntryPoint = "duckdb_column_name")]
-        public static extern string DuckDBColumnName(DuckDBResult result, long col);
+        public static extern string DuckDBColumnName([In, Out] DuckDBResult result, long col);
 
         [DllImport(DuckDbLibrary, CallingConvention = CallingConvention.Cdecl, EntryPoint = "duckdb_value_boolean")]
-        public static extern bool DuckDBValueBoolean(DuckDBResult result, long col, long row);
+        public static extern bool DuckDBValueBoolean([In, Out] DuckDBResult result, long col, long row);
 
         [DllImport(DuckDbLibrary, CallingConvention = CallingConvention.Cdecl, EntryPoint = "duckdb_value_int8")]
-        public static extern sbyte DuckDBValueInt8(DuckDBResult result, long col, long row);
+        public static extern sbyte DuckDBValueInt8([In, Out] DuckDBResult result, long col, long row);
 
         [DllImport(DuckDbLibrary, CallingConvention = CallingConvention.Cdecl, EntryPoint = "duckdb_value_int16")]
-        public static extern short DuckDBValueInt16(DuckDBResult result, long col, long row);
+        public static extern short DuckDBValueInt16([In, Out] DuckDBResult result, long col, long row);
 
         [DllImport(DuckDbLibrary, CallingConvention = CallingConvention.Cdecl, EntryPoint = "duckdb_value_int32")]
-        public static extern int DuckDBValueInt32(DuckDBResult result, long col, long row);
+        public static extern int DuckDBValueInt32([In, Out] DuckDBResult result, long col, long row);
 
         [DllImport(DuckDbLibrary, CallingConvention = CallingConvention.Cdecl, EntryPoint = "duckdb_value_int64")]
-        public static extern long DuckDBValueInt64(DuckDBResult result, long col, long row);
+        public static extern long DuckDBValueInt64([In, Out] DuckDBResult result, long col, long row);
 
         [DllImport(DuckDbLibrary, CallingConvention = CallingConvention.Cdecl, EntryPoint = "duckdb_value_float")]
-        public static extern float DuckDBValueFloat(DuckDBResult result, long col, long row);
+        public static extern float DuckDBValueFloat([In, Out] DuckDBResult result, long col, long row);
 
         [DllImport(DuckDbLibrary, CallingConvention = CallingConvention.Cdecl, EntryPoint = "duckdb_value_double")]
-        public static extern double DuckDBValueDouble(DuckDBResult result, long col, long row);
+        public static extern double DuckDBValueDouble([In, Out] DuckDBResult result, long col, long row);
         
         [DllImport(DuckDbLibrary, CallingConvention = CallingConvention.Cdecl, EntryPoint = "duckdb_value_varchar")]
-        public static extern IntPtr DuckDBValueVarchar(DuckDBResult result, long col, long row);
+        public static extern IntPtr DuckDBValueVarchar([In, Out] DuckDBResult result, long col, long row);
 
         [DllImport(DuckDbLibrary, CallingConvention = CallingConvention.Cdecl, EntryPoint = "duckdb_prepare")]
         public static extern DuckDBState DuckDBPrepare(DuckDBNativeConnection connection, string query, out DuckDBPreparedStatement preparedStatement);
@@ -238,7 +238,7 @@ namespace DuckDB.NET.Windows
         public static extern DuckDBState DuckDBBindNull(DuckDBPreparedStatement preparedStatement, long index);
 
         [DllImport(DuckDbLibrary, CallingConvention = CallingConvention.Cdecl, EntryPoint = "duckdb_execute_prepared")]
-        public static extern DuckDBState DuckDBExecutePrepared(DuckDBPreparedStatement preparedStatement, out DuckDBResult result);
+        public static extern DuckDBState DuckDBExecutePrepared(DuckDBPreparedStatement preparedStatement, [In, Out] DuckDBResult result);
 
         [DllImport(DuckDbLibrary, CallingConvention = CallingConvention.Cdecl, EntryPoint = "duckdb_destroy_prepare")]
         public static extern void DuckDBDestroyPrepare(out IntPtr preparedStatement);


### PR DESCRIPTION
This pull request converts DuckDBResult to a class instead of a struct. This is to avoid copying DuckDBResult at some steps. This could alternatively be done by adding ref to all the methods taking a DuckDBResult.

This changes the interface for the methods that "returns" a DuckDBResult from:

```
var queryResult = new DuckDBResult();
result = DuckDBQuery(connection, "CREATE TABLE integers(foo INTEGER, bar INTEGER);", out queryResult);
```
or alternatively:

```
result = DuckDBQuery(connection, "CREATE TABLE integers(foo INTEGER, bar INTEGER);", out var queryResult);
```


to:

```
var queryResult = new DuckDBResult();
result = DuckDBQuery(connection, "CREATE TABLE integers(foo INTEGER, bar INTEGER);", queryResult);
```

This change will also enable passing `null` instead of an instance of DuckDBResult.