### PR TITLE
Replace deprecated fields with calls to bindings.

### DIFF
--- a/DuckDB.NET.Data/DuckDBCommand.cs
+++ b/DuckDB.NET.Data/DuckDBCommand.cs
@@ -45,9 +45,10 @@ namespace DuckDB.NET.Data
             var queryResult = new DuckDBResult();
             var result = PlatformIndependentBindings.NativeMethods.DuckDBQuery(connection.NativeConnection, unmanagedString, queryResult);
 
-            if (!string.IsNullOrEmpty(queryResult.ErrorMessage))
+            var errorMessage = PlatformIndependentBindings.NativeMethods.DuckDBResultError(queryResult);
+            if (!string.IsNullOrEmpty(errorMessage))
             {
-                throw new DuckDBException(queryResult.ErrorMessage, result);
+                throw new DuckDBException(errorMessage, result);
             }
 
             if (!result.IsSuccess())
@@ -55,7 +56,9 @@ namespace DuckDB.NET.Data
                 throw new DuckDBException("DuckDBQuery failed", result);
             }
 
-            if (queryResult.ColumnCount > 0 && queryResult.RowCount > 0)
+            var rowCount = PlatformIndependentBindings.NativeMethods.DuckDBRowCount(queryResult);
+            var columnCount = PlatformIndependentBindings.NativeMethods.DuckDBColumnCount(queryResult);
+            if (columnCount > 0 && rowCount > 0)
             {
                 return PlatformIndependentBindings.NativeMethods.DuckDBValueInt32(queryResult, 0, 0);
             }

--- a/DuckDB.NET.Samples/Program.cs
+++ b/DuckDB.NET.Samples/Program.cs
@@ -127,19 +127,19 @@ namespace DuckDB.NET.Samples
 
         private static void PrintQueryResults(DuckDBResult queryResult)
         {
-            for (var index = 0; index < queryResult.Columns.Count; index++)
+            var columnCount = DuckDBColumnCount(queryResult);
+            for (var index = 0; index < columnCount; index++)
             {
-                var column = queryResult.Columns[index];
-                Console.Write($"{column.Name} ");
-                
-                Debug.Assert(column.Name == DuckDBColumnName(queryResult, index).ToManagedString(false));
+                var columnName = DuckDBColumnName(queryResult, index).ToManagedString(false);
+                Console.Write($"{columnName} ");
             }
 
             Console.WriteLine();
 
-            for (long row = 0; row < queryResult.RowCount; row++)
+            var rowCount = DuckDBRowCount(queryResult);
+            for (long row = 0; row < rowCount; row++)
             {
-                for (long column = 0; column < queryResult.ColumnCount; column++)
+                for (long column = 0; column < columnCount; column++)
                 {
                     var val = DuckDBValueInt32(queryResult, column, row);
                     Console.Write(val);

--- a/DuckDB.NET/DuckDBNativeObjects.cs
+++ b/DuckDB.NET/DuckDBNativeObjects.cs
@@ -54,15 +54,19 @@ namespace DuckDB.NET
     [StructLayout(LayoutKind.Sequential)]
     public class DuckDBResult
     {
-        // Deprecated
+        [Obsolete]
         private long ColumnCount;
-        // Deprecated
+
+        [Obsolete]
         private long RowCount;
-        // Deprecated
+
+        [Obsolete]
         private long RowsChanged;
-        // Deprecated
+
+        [Obsolete]
         private IntPtr columns;
-        // Deprecated
+
+        [Obsolete]
         private string ErrorMessage;
 
         private IntPtr internal_data;

--- a/DuckDB.NET/DuckDBNativeObjects.cs
+++ b/DuckDB.NET/DuckDBNativeObjects.cs
@@ -52,51 +52,20 @@ namespace DuckDB.NET
     }
 
     [StructLayout(LayoutKind.Sequential)]
-    public struct DuckDBColumn
-    {
-        IntPtr data;
-        IntPtr nullmask;
-
-        public DuckDBType Type { get; }
-        public string Name { get; }
-        IntPtr internal_data;
-
-        public bool NullMask(int row) => Marshal.ReadByte(nullmask + row) != 0;
-        public IntPtr Data => data;
-
-        public T ReadAs<T>(int row) where T : struct
-        {
-            return Marshal.PtrToStructure<T>(Data + Marshal.SizeOf<T>() * row);
-        }
-    }
-
-    [StructLayout(LayoutKind.Sequential)]
     public class DuckDBResult
     {
-        public long ColumnCount { get; }
-        public long RowCount { get; }
-        public long RowsChanged { get; }
-
+        // Deprecated
+        private long ColumnCount;
+        // Deprecated
+        private long RowCount;
+        // Deprecated
+        private long RowsChanged;
+        // Deprecated
         private IntPtr columns;
+        // Deprecated
+        private string ErrorMessage;
 
-        public string ErrorMessage { get; }
-        IntPtr internal_data;
-
-        public IReadOnlyList<DuckDBColumn> Columns
-        {
-            get
-            {
-                var result = new List<DuckDBColumn>();
-
-                for (int i = 0; i < ColumnCount; i++)
-                {
-                    var column = Marshal.PtrToStructure<DuckDBColumn>(columns + Marshal.SizeOf<DuckDBColumn>() * i);
-                    result.Add(column);
-                }
-
-                return result.AsReadOnly();
-            }
-        }
+        private IntPtr internal_data;
     }
 
     public struct DuckDBDate


### PR DESCRIPTION
This PR replace use of deprecated fields in DuckDBResult to the newly added recommended bindings (see [https://github.com/duckdb/duckdb/blob/master/src/include/duckdb.h#L214](https://github.com/duckdb/duckdb/blob/master/src/include/duckdb.h#L214)).

Feedback is welcome.