### PR TITLE
Fix error when calling result helpers.

### DIFF
--- a/DuckDB.NET/Linux/NativeMethods.Linux.cs
+++ b/DuckDB.NET/Linux/NativeMethods.Linux.cs
@@ -224,25 +224,25 @@ namespace DuckDB.NET.Linux
         public static extern IntPtr DuckDBColumnName([In, Out] DuckDBResult result, long col);
 
         [DllImport(DuckDbLibrary, CallingConvention = CallingConvention.Cdecl, EntryPoint = "duckdb_column_type")]
-        public static extern DuckDBType DuckDBColumnType(DuckDBResult result, long col);
+        public static extern DuckDBType DuckDBColumnType([In, Out] DuckDBResult result, long col);
 
         [DllImport(DuckDbLibrary, CallingConvention = CallingConvention.Cdecl, EntryPoint = "duckdb_column_count")]
-        public static extern long DuckDBColumnCount(DuckDBResult result);
+        public static extern long DuckDBColumnCount([In, Out] DuckDBResult result);
 
         [DllImport(DuckDbLibrary, CallingConvention = CallingConvention.Cdecl, EntryPoint = "duckdb_row_count")]
-        public static extern long DuckDBRowCount(DuckDBResult result);
+        public static extern long DuckDBRowCount([In, Out] DuckDBResult result);
 
         [DllImport(DuckDbLibrary, CallingConvention = CallingConvention.Cdecl, EntryPoint = "duckdb_rows_changed")]
-        public static extern long DuckDBRowsChanged(DuckDBResult result);
+        public static extern long DuckDBRowsChanged([In, Out] DuckDBResult result);
 
         [DllImport(DuckDbLibrary, CallingConvention = CallingConvention.Cdecl, EntryPoint = "duckdb_column_data")]
-        public static extern IntPtr DuckDBColumnData(DuckDBResult result, long col);
+        public static extern IntPtr DuckDBColumnData([In, Out] DuckDBResult result, long col);
 
         [DllImport(DuckDbLibrary, CallingConvention = CallingConvention.Cdecl, EntryPoint = "duckdb_nullmask_data")]
-        public static extern IntPtr DuckDBNullmaskData(DuckDBResult result, long col);
+        public static extern IntPtr DuckDBNullmaskData([In, Out] DuckDBResult result, long col);
 
         [DllImport(DuckDbLibrary, CallingConvention = CallingConvention.Cdecl, EntryPoint = "duckdb_result_error")]
-        public static extern IntPtr DuckDBResultError(DuckDBResult result);
+        public static extern IntPtr DuckDBResultError([In, Out] DuckDBResult result);
 
         [DllImport(DuckDbLibrary, CallingConvention = CallingConvention.Cdecl, EntryPoint = "duckdb_value_boolean")]
         public static extern bool DuckDBValueBoolean([In, Out] DuckDBResult result, long col, long row);

--- a/DuckDB.NET/MacOS/NativeMethods.MacOS.cs
+++ b/DuckDB.NET/MacOS/NativeMethods.MacOS.cs
@@ -224,25 +224,25 @@ namespace DuckDB.NET.MacOS
         public static extern IntPtr DuckDBColumnName([In, Out] DuckDBResult result, long col);
 
         [DllImport(DuckDbLibrary, CallingConvention = CallingConvention.Cdecl, EntryPoint = "duckdb_column_type")]
-        public static extern DuckDBType DuckDBColumnType(DuckDBResult result, long col);
+        public static extern DuckDBType DuckDBColumnType([In, Out] DuckDBResult result, long col);
 
         [DllImport(DuckDbLibrary, CallingConvention = CallingConvention.Cdecl, EntryPoint = "duckdb_column_count")]
-        public static extern long DuckDBColumnCount(DuckDBResult result);
+        public static extern long DuckDBColumnCount([In, Out] DuckDBResult result);
 
         [DllImport(DuckDbLibrary, CallingConvention = CallingConvention.Cdecl, EntryPoint = "duckdb_row_count")]
-        public static extern long DuckDBRowCount(DuckDBResult result);
+        public static extern long DuckDBRowCount([In, Out] DuckDBResult result);
 
         [DllImport(DuckDbLibrary, CallingConvention = CallingConvention.Cdecl, EntryPoint = "duckdb_rows_changed")]
-        public static extern long DuckDBRowsChanged(DuckDBResult result);
+        public static extern long DuckDBRowsChanged([In, Out] DuckDBResult result);
 
         [DllImport(DuckDbLibrary, CallingConvention = CallingConvention.Cdecl, EntryPoint = "duckdb_column_data")]
-        public static extern IntPtr DuckDBColumnData(DuckDBResult result, long col);
+        public static extern IntPtr DuckDBColumnData([In, Out] DuckDBResult result, long col);
 
         [DllImport(DuckDbLibrary, CallingConvention = CallingConvention.Cdecl, EntryPoint = "duckdb_nullmask_data")]
-        public static extern IntPtr DuckDBNullmaskData(DuckDBResult result, long col);
+        public static extern IntPtr DuckDBNullmaskData([In, Out] DuckDBResult result, long col);
 
         [DllImport(DuckDbLibrary, CallingConvention = CallingConvention.Cdecl, EntryPoint = "duckdb_result_error")]
-        public static extern IntPtr DuckDBResultError(DuckDBResult result);
+        public static extern IntPtr DuckDBResultError([In, Out] DuckDBResult result);
 
         [DllImport(DuckDbLibrary, CallingConvention = CallingConvention.Cdecl, EntryPoint = "duckdb_value_boolean")]
         public static extern bool DuckDBValueBoolean([In, Out] DuckDBResult result, long col, long row);

--- a/DuckDB.NET/Windows/NativeMethods.Windows.cs
+++ b/DuckDB.NET/Windows/NativeMethods.Windows.cs
@@ -224,25 +224,25 @@ namespace DuckDB.NET.Windows
         public static extern IntPtr DuckDBColumnName([In, Out] DuckDBResult result, long col);
 
         [DllImport(DuckDbLibrary, CallingConvention = CallingConvention.Cdecl, EntryPoint = "duckdb_column_type")]
-        public static extern DuckDBType DuckDBColumnType(DuckDBResult result, long col);
+        public static extern DuckDBType DuckDBColumnType([In, Out] DuckDBResult result, long col);
 
         [DllImport(DuckDbLibrary, CallingConvention = CallingConvention.Cdecl, EntryPoint = "duckdb_column_count")]
-        public static extern long DuckDBColumnCount(DuckDBResult result);
+        public static extern long DuckDBColumnCount([In, Out] DuckDBResult result);
 
         [DllImport(DuckDbLibrary, CallingConvention = CallingConvention.Cdecl, EntryPoint = "duckdb_row_count")]
-        public static extern long DuckDBRowCount(DuckDBResult result);
+        public static extern long DuckDBRowCount([In, Out] DuckDBResult result);
 
         [DllImport(DuckDbLibrary, CallingConvention = CallingConvention.Cdecl, EntryPoint = "duckdb_rows_changed")]
-        public static extern long DuckDBRowsChanged(DuckDBResult result);
+        public static extern long DuckDBRowsChanged([In, Out] DuckDBResult result);
 
         [DllImport(DuckDbLibrary, CallingConvention = CallingConvention.Cdecl, EntryPoint = "duckdb_column_data")]
-        public static extern IntPtr DuckDBColumnData(DuckDBResult result, long col);
+        public static extern IntPtr DuckDBColumnData([In, Out] DuckDBResult result, long col);
 
         [DllImport(DuckDbLibrary, CallingConvention = CallingConvention.Cdecl, EntryPoint = "duckdb_nullmask_data")]
-        public static extern IntPtr DuckDBNullmaskData(DuckDBResult result, long col);
+        public static extern IntPtr DuckDBNullmaskData([In, Out] DuckDBResult result, long col);
 
         [DllImport(DuckDbLibrary, CallingConvention = CallingConvention.Cdecl, EntryPoint = "duckdb_result_error")]
-        public static extern IntPtr DuckDBResultError(DuckDBResult result);
+        public static extern IntPtr DuckDBResultError([In, Out] DuckDBResult result);
 
         [DllImport(DuckDbLibrary, CallingConvention = CallingConvention.Cdecl, EntryPoint = "duckdb_value_boolean")]
         public static extern bool DuckDBValueBoolean([In, Out] DuckDBResult result, long col, long row);


### PR DESCRIPTION
Result was not passed with [In, Out] decoration which resulted in errors thrown which was discovered after merging #33.