### PR TITLE
Run CI on pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-on: push
+on: [push, pull_request]
 
 env:
   DUCKDB_GIT_TAG: 'v0.3.4'


### PR DESCRIPTION
This PR makes GitHub run CI not only on push, but also for all pull requests. As a result we can merge only iff a PR does not break builds.