### PR TITLE
Parse connection string, introduce connection string builder

### DIFF
--- a/DuckDB.NET.Data/ConnectionString/DuckDBConnectionStringParser.cs
+++ b/DuckDB.NET.Data/ConnectionString/DuckDBConnectionStringParser.cs
@@ -1,0 +1,37 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace DuckDB.NET.Data.ConnectionString
+{
+    internal static class DuckDBConnectionStringParser
+    {
+        private static readonly HashSet<string> DataSourceKeys 
+            = new HashSet<string>(new []{"Data Source", "DataSource"}, StringComparer.OrdinalIgnoreCase);
+        
+        public static IDuckDBConnectionString Parse(string connectionString)
+        {
+            return new DuckDBConnectionString(GetFileName(connectionString));
+        }
+        
+        private static string GetFileName(string connectionString)
+        {
+            var connectionStringParts = connectionString.Split('=').Select(x => x.Trim()).ToArray();
+            if (connectionStringParts.Length != 2)
+            {
+                throw new InvalidOperationException($"ConnectionString '{connectionString}' is not valid");
+            }
+
+            if (!DataSourceKeys.Contains(connectionStringParts[0]))
+            {
+                throw new InvalidOperationException($"ConnectionString '{connectionString}' is not valid");
+            }
+
+            return IsInMemoryDataSource(connectionStringParts[1])
+                ? string.Empty
+                : connectionStringParts[1];
+        }
+        
+        private static bool IsInMemoryDataSource(string dataSource) => dataSource.Equals(DuckDBConnectionStringBuilder.InMemory, StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/DuckDB.NET.Data/ConnectionString/IDuckDBConnectionString.cs
+++ b/DuckDB.NET.Data/ConnectionString/IDuckDBConnectionString.cs
@@ -1,11 +1,6 @@
 namespace DuckDB.NET.Data.ConnectionString
 {
-    internal interface IDuckDBConnectionString
-    {
-        string DataSource { get; }
-    }
-
-    internal class DuckDBConnectionString : IDuckDBConnectionString
+    internal class DuckDBConnectionString
     {
         public string DataSource { get; }
 

--- a/DuckDB.NET.Data/ConnectionString/IDuckDBConnectionString.cs
+++ b/DuckDB.NET.Data/ConnectionString/IDuckDBConnectionString.cs
@@ -1,0 +1,17 @@
+namespace DuckDB.NET.Data.ConnectionString
+{
+    internal interface IDuckDBConnectionString
+    {
+        string DataSource { get; }
+    }
+
+    internal class DuckDBConnectionString : IDuckDBConnectionString
+    {
+        public string DataSource { get; }
+
+        public DuckDBConnectionString(string dataSource)
+        {
+            DataSource = dataSource;
+        }
+    }
+}

--- a/DuckDB.NET.Data/DuckDBConnection.cs
+++ b/DuckDB.NET.Data/DuckDBConnection.cs
@@ -12,19 +12,12 @@ namespace DuckDB.NET.Data
         private ConnectionManager connectionManager = ConnectionManager.Default;
         private ConnectionReference connectionReference;
         private ConnectionState connectionState = ConnectionState.Closed;
-        private readonly DuckDBConnectionStringBuilder? connectionStringBuilder = null; 
 
         internal DbTransaction? Transaction { get; set; }
 
         public DuckDBConnection(string connectionString)
         {
             ConnectionString = connectionString;
-        }
-
-        public DuckDBConnection(DuckDBConnectionStringBuilder builder)
-        {
-            connectionStringBuilder = builder;
-            ConnectionString = builder.ToString();
         }
 
         public override string ConnectionString { get; set; }
@@ -61,7 +54,7 @@ namespace DuckDB.NET.Data
                 throw new InvalidOperationException("Connection is already open.");
             }
 
-            var connectionString = connectionStringBuilder ?? DuckDBConnectionStringParser.Parse(ConnectionString);
+            var connectionString = DuckDBConnectionStringParser.Parse(ConnectionString);
 
             connectionReference = connectionManager.GetConnectionReference(connectionString);
 

--- a/DuckDB.NET.Data/DuckDBConnection.cs
+++ b/DuckDB.NET.Data/DuckDBConnection.cs
@@ -3,6 +3,7 @@ using System;
 using System.Data;
 using System.Data.Common;
 using System.Runtime.CompilerServices;
+using DuckDB.NET.Data.ConnectionString;
 
 namespace DuckDB.NET.Data
 {
@@ -11,12 +12,19 @@ namespace DuckDB.NET.Data
         private ConnectionManager connectionManager = ConnectionManager.Default;
         private ConnectionReference connectionReference;
         private ConnectionState connectionState = ConnectionState.Closed;
+        private readonly DuckDBConnectionStringBuilder? connectionStringBuilder = null; 
 
         internal DbTransaction? Transaction { get; set; }
 
         public DuckDBConnection(string connectionString)
         {
             ConnectionString = connectionString;
+        }
+
+        public DuckDBConnection(DuckDBConnectionStringBuilder builder)
+        {
+            connectionStringBuilder = builder;
+            ConnectionString = builder.ToString();
         }
 
         public override string ConnectionString { get; set; }
@@ -53,7 +61,9 @@ namespace DuckDB.NET.Data
                 throw new InvalidOperationException("Connection is already open.");
             }
 
-            connectionReference = connectionManager.GetConnectionReference(ConnectionString);
+            var connectionString = connectionStringBuilder ?? DuckDBConnectionStringParser.Parse(ConnectionString);
+
+            connectionReference = connectionManager.GetConnectionReference(connectionString);
 
             connectionState = ConnectionState.Open;
         }

--- a/DuckDB.NET.Data/DuckDBConnectionStringBuilder.cs
+++ b/DuckDB.NET.Data/DuckDBConnectionStringBuilder.cs
@@ -1,22 +1,21 @@
-using System;
-using DuckDB.NET.Data.ConnectionString;
+using System.Data.Common;
 
 namespace DuckDB.NET.Data
 {
-    public class DuckDBConnectionStringBuilder : IDuckDBConnectionString
+    public class DuckDBConnectionStringBuilder : DbConnectionStringBuilder
     {
-        public const string InMemory = ":memory:";
+        public const string InMemoryDataSource = ":memory:";
+        public const string InMemoryConnectionString = "DataSource=:memory:";
         
-        public string DataSource { get; set; }
+        internal static readonly string[] DataSourceKeys = {"Data Source", "DataSource"};
+        private const string DataSourceKey = "DataSource";
 
-        public override string ToString()
+        private string dataSource = null;
+        
+        public string DataSource
         {
-            if (string.IsNullOrEmpty(DataSource))
-            {
-                throw new InvalidCastException("DataSource must be specified.");
-            }
-
-            return $"DataSource = {DataSource}";
+            get => dataSource;
+            set => this[DataSourceKey] = dataSource = value;
         }
     }
 }

--- a/DuckDB.NET.Data/DuckDBConnectionStringBuilder.cs
+++ b/DuckDB.NET.Data/DuckDBConnectionStringBuilder.cs
@@ -1,0 +1,22 @@
+using System;
+using DuckDB.NET.Data.ConnectionString;
+
+namespace DuckDB.NET.Data
+{
+    public class DuckDBConnectionStringBuilder : IDuckDBConnectionString
+    {
+        public const string InMemory = ":memory:";
+        
+        public string DataSource { get; set; }
+
+        public override string ToString()
+        {
+            if (string.IsNullOrEmpty(DataSource))
+            {
+                throw new InvalidCastException("DataSource must be specified.");
+            }
+
+            return $"DataSource = {DataSource}";
+        }
+    }
+}

--- a/DuckDB.NET.Data/Internal/ConnectionManager.cs
+++ b/DuckDB.NET.Data/Internal/ConnectionManager.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Concurrent;
 using System.Threading;
+using DuckDB.NET.Data.ConnectionString;
 
 namespace DuckDB.NET.Data.Internal
 {
@@ -13,9 +14,9 @@ namespace DuckDB.NET.Data.Internal
 
         private static readonly ConcurrentDictionary<string, FileRef> ConnectionCache = new(StringComparer.OrdinalIgnoreCase);
 
-        internal ConnectionReference GetConnectionReference(string connectionString)
+        internal ConnectionReference GetConnectionReference(IDuckDBConnectionString connectionString)
         {
-            string filename = GetFileName(connectionString);
+            var filename = connectionString.DataSource;
 
             FileRef fileRef = null;
 
@@ -109,32 +110,6 @@ namespace DuckDB.NET.Data.Internal
                     }
                 }
             }
-        }
-                
-        private string GetFileName(string connectionString)
-        {
-            string filename = null;
-
-            if (connectionString.StartsWith("Data Source=") || connectionString.StartsWith("DataSource="))
-            {
-                var strings = connectionString.Split('=');
-
-                if (strings[1] == ":memory:")
-                {
-                    filename = "";
-                }
-                else
-                {
-                    filename = strings[1];
-                }
-            }
-
-            if (filename == null)
-            {
-                throw new InvalidOperationException($"ConnectionString '{connectionString}' is not valid");
-            }
-
-            return filename;
         }
     }
 }

--- a/DuckDB.NET.Data/Internal/ConnectionManager.cs
+++ b/DuckDB.NET.Data/Internal/ConnectionManager.cs
@@ -14,7 +14,7 @@ namespace DuckDB.NET.Data.Internal
 
         private static readonly ConcurrentDictionary<string, FileRef> ConnectionCache = new(StringComparer.OrdinalIgnoreCase);
 
-        internal ConnectionReference GetConnectionReference(IDuckDBConnectionString connectionString)
+        internal ConnectionReference GetConnectionReference(DuckDBConnectionString connectionString)
         {
             var filename = connectionString.DataSource;
 

--- a/DuckDB.NET.Test/ConnectionStringTests.cs
+++ b/DuckDB.NET.Test/ConnectionStringTests.cs
@@ -20,6 +20,7 @@ namespace DuckDB.NET.Test
         [InlineData("Data Source    =:memory:")]
         [InlineData("DataSource=:Memory:")]
         [InlineData("Data Source=:Memory:")]
+        [InlineData(DuckDBConnectionStringBuilder.InMemoryConnectionString)]
         public void ExplicitConnectionStringTest(string connectionString)
         {
             using var connection = new DuckDBConnection(connectionString);
@@ -41,14 +42,11 @@ namespace DuckDB.NET.Test
         {
             var builder = new DuckDBConnectionStringBuilder
             {
-                DataSource = DuckDBConnectionStringBuilder.InMemory
+                DataSource = DuckDBConnectionStringBuilder.InMemoryDataSource
             };
 
             using var connection = new DuckDBConnection(builder.ToString());
             connection.Open();
-
-            using var connection2 = new DuckDBConnection(builder);
-            connection2.Open();
         }
     }
 }

--- a/DuckDB.NET.Test/ConnectionStringTests.cs
+++ b/DuckDB.NET.Test/ConnectionStringTests.cs
@@ -1,0 +1,54 @@
+using System;
+using DuckDB.NET.Data;
+using FluentAssertions;
+using Xunit;
+
+namespace DuckDB.NET.Test
+{
+    public class ConnectionStringTests
+    {
+        [Theory]
+        [InlineData("DataSource=:memory:")]
+        [InlineData("DataSource = :memory:")]
+        [InlineData("Data Source=:memory:")]
+        [InlineData("Data Source = :memory:")]
+        [InlineData("DataSource=   :memory:")]
+        [InlineData("Data Source=    :memory:")]
+        [InlineData("DataSource   =   :memory:")]
+        [InlineData("Data Source    =    :memory:")]
+        [InlineData("DataSource   =:memory:")]
+        [InlineData("Data Source    =:memory:")]
+        [InlineData("DataSource=:Memory:")]
+        [InlineData("Data Source=:Memory:")]
+        public void ExplicitConnectionStringTest(string connectionString)
+        {
+            using var connection = new DuckDBConnection(connectionString);
+            connection.Open();
+        }
+        
+        [Theory]
+        [InlineData("Source=:memory:")]
+        [InlineData("Data=:memory:")]
+        public void InvalidConnectionStringTests(string connectionString)
+        {
+            using var connection = new DuckDBConnection(connectionString);
+            connection.Invoking(con => con.Open())
+                .Should().Throw<InvalidOperationException>();
+        }
+
+        [Fact]
+        public void ConnectionStringBuilderTest()
+        {
+            var builder = new DuckDBConnectionStringBuilder
+            {
+                DataSource = DuckDBConnectionStringBuilder.InMemory
+            };
+
+            using var connection = new DuckDBConnection(builder.ToString());
+            connection.Open();
+
+            using var connection2 = new DuckDBConnection(builder);
+            connection2.Open();
+        }
+    }
+}

--- a/DuckDB.NET.Test/DuckDBConnectionTests.cs
+++ b/DuckDB.NET.Test/DuckDBConnectionTests.cs
@@ -239,7 +239,7 @@ namespace DuckDB.NET.Test
                 var command = con.CreateCommand();
                 command.CommandText = "SELECT 42;";
                 command.ExecuteScalar();
-            }).Should().ThrowExactly<DuckDBException>();
+            }).Should().ThrowExactly<InvalidOperationException>();
             
             connection.Open();
             connection.State.Should().Be(ConnectionState.Open);


### PR DESCRIPTION
This pull request brings a new `DuckDBConnectionStringBuilder` class that lets to format a connections string. This PR also changes connection string parsing so that we allow spaces around `=`.

Fix #42 