### PR TITLE
Add Decimal type

### DIFF
--- a/DuckDB.NET.Data/DuckDBDataReader.cs
+++ b/DuckDB.NET.Data/DuckDBDataReader.cs
@@ -105,7 +105,8 @@ namespace DuckDB.NET.Data
                 DuckDBType.DuckdbTypeInterval => throw new NotImplementedException(),
                 DuckDBType.DuckdbTypeHugeInt => typeof(BigInteger),
                 DuckDBType.DuckdbTypeVarchar => typeof(string),
-                _ => throw new ArgumentException("Unrecognised type")
+                DuckDBType.DuckdbTypeDecimal => typeof(Decimal),
+                var typ => throw new ArgumentException($"Unrecognised type {typ} in column {ordinal+1}")
             };
         }
 


### PR DESCRIPTION
On one of my cases `SELECT 0.0` in DuckDb internally resolved to decimal which DuckDb.NET failed to recognise.

I've added a line into `GetFieldType` to add Decimal.