### PR TITLE
Call DuckDBDestroyResult even on success

### DIFF
--- a/DuckDB.NET.Data/DuckDBCommand.cs
+++ b/DuckDB.NET.Data/DuckDBCommand.cs
@@ -34,7 +34,8 @@ namespace DuckDB.NET.Data
             
             using var unmanagedString = CommandText.ToUnmanagedString();
             var queryResult = new DuckDBResult();
-            try {
+            try
+            {
                 var result = NativeMethods.Query.DuckDBQuery(connection.NativeConnection, unmanagedString, queryResult);
 
                 if (!result.IsSuccess())
@@ -45,7 +46,8 @@ namespace DuckDB.NET.Data
 
                 return (int)NativeMethods.Query.DuckDBRowsChanged(queryResult);
             }
-            finally {
+            finally
+            {
                 NativeMethods.Query.DuckDBDestroyResult(queryResult);
             }
         }


### PR DESCRIPTION
DuckDb API doca are suggesting to call `duckdb_destroy_result` after each query to  
*"de-allocate all memory allocated for that connection"*.

In `DuckDDCommand.ExecuteNonQuery` we called `DuckDBDestroyResult` only for error path,  
but we didn't destroy the result for the success path.