### PR TITLE
Simplify Utils.ToManagedString

### DIFF
--- a/DuckDB.NET.Data/DuckDB.NET.Data.csproj
+++ b/DuckDB.NET.Data/DuckDB.NET.Data.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageId>DuckDB.NET.Data</PackageId>
     <Authors>Giorgi Dalakishvili</Authors>

--- a/DuckDB.NET/DuckDB.NET.csproj
+++ b/DuckDB.NET/DuckDB.NET.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageId>DuckDB.NET.Bindings</PackageId>
     <Authors>Giorgi Dalakishvili</Authors>

--- a/DuckDB.NET/Utils.cs
+++ b/DuckDB.NET/Utils.cs
@@ -18,28 +18,14 @@ namespace DuckDB.NET
                 return "";
             }
 
-            var length = 0;
-
-            while (Marshal.ReadByte(unmanagedString, length) != 0)
-            {
-                length++;
-            }
-
-            if (length == 0)
-            {
-                return string.Empty;
-            }
-
-            var byteArray = new byte[length];
-
-            Marshal.Copy(unmanagedString, byteArray, 0, length);
+            var result = Marshal.PtrToStringAnsi(unmanagedString);
 
             if (freeWhenCopied)
             {
                 NativeMethods.Helpers.DuckDBFree(unmanagedString);
             }
 
-            return Encoding.UTF8.GetString(byteArray, 0, length);
+            return result;
         }
 
         public static SafeUnmanagedMemoryHandle ToUnmanagedString(this string managedString)

--- a/DuckDB.NET/Utils.cs
+++ b/DuckDB.NET/Utils.cs
@@ -18,7 +18,7 @@ namespace DuckDB.NET
                 return "";
             }
 
-            var result = Marshal.PtrToStringAnsi(unmanagedString);
+            var result = Marshal.PtrToStringUTF8(unmanagedString);
 
             if (freeWhenCopied)
             {


### PR DESCRIPTION
`Marshal.PtrToStringAnsi` does the same as what we were doing manually,  
but without extra allocation for `byteArray`.