### PR TITLE
Support for TimeOnly, DateOnly & Timestamp

### DIFF
--- a/DuckDB.NET.Data/DuckDBDataReader.cs
+++ b/DuckDB.NET.Data/DuckDBDataReader.cs
@@ -68,8 +68,21 @@ namespace DuckDB.NET.Data
 
         public override DateTime GetDateTime(int ordinal)
         {
-            var text = GetString(ordinal);
-            return DateTime.Parse(text, null, DateTimeStyles.RoundtripKind);
+            var timestampStruct = NativeMethods.Types.DuckDbValueTimestamp(queryResult, ordinal, currentRow);
+            var timestamp = NativeMethods.DateTime.DuckDBFromTimestamp(timestampStruct);
+            return timestamp.ToDateTime();
+        }
+
+        public DuckDBDateOnly GetDateOnly(int ordinal)
+        {
+            var date = NativeMethods.Types.DuckDbValueDate(queryResult, ordinal, currentRow);
+            return NativeMethods.DateTime.DuckDBFromDate(date);
+        }
+
+        public DuckDBTimeOnly GetTimeOnly(int ordinal)
+        {
+            var time = NativeMethods.Types.DuckDbValueTime(queryResult, ordinal, currentRow);
+            return NativeMethods.DateTime.DuckDBFromTime(time);
         }
 
         public override decimal GetDecimal(int ordinal)
@@ -107,9 +120,9 @@ namespace DuckDB.NET.Data
                 DuckDBType.DuckdbTypeFloat => typeof(float),
                 DuckDBType.DuckdbTypeDouble => typeof(double),
                 DuckDBType.DuckdbTypeTimestamp => typeof(DateTime),
-                DuckDBType.DuckdbTypeDate => typeof(DateTime),
-                DuckDBType.DuckdbTypeTime => typeof(DateTime),
                 DuckDBType.DuckdbTypeInterval => typeof(DuckDBInterval),
+                DuckDBType.DuckdbTypeDate => typeof(DuckDBDateOnly),
+                DuckDBType.DuckdbTypeTime => typeof(DuckDBTimeOnly),
                 DuckDBType.DuckdbTypeHugeInt => typeof(BigInteger),
                 DuckDBType.DuckdbTypeVarchar => typeof(string),
                 DuckDBType.DuckdbTypeDecimal => typeof(decimal),
@@ -212,9 +225,9 @@ namespace DuckDB.NET.Data
                 DuckDBType.DuckdbTypeFloat => GetFloat(ordinal),
                 DuckDBType.DuckdbTypeDouble => GetDouble(ordinal),
                 DuckDBType.DuckdbTypeTimestamp => GetDateTime(ordinal),
-                DuckDBType.DuckdbTypeDate => GetDateTime(ordinal),
-                DuckDBType.DuckdbTypeTime => GetDateTime(ordinal),
                 DuckDBType.DuckdbTypeInterval => GetDuckDBInterval(ordinal),
+                DuckDBType.DuckdbTypeDate => GetDateOnly(ordinal),
+                DuckDBType.DuckdbTypeTime => GetTimeOnly(ordinal),
                 DuckDBType.DuckdbTypeHugeInt => GetBigInteger(ordinal),
                 DuckDBType.DuckdbTypeVarchar => GetString(ordinal),
                 DuckDBType.DuckdbTypeDecimal => GetDecimal(ordinal),

--- a/DuckDB.NET.Data/DuckDBParameter.cs
+++ b/DuckDB.NET.Data/DuckDBParameter.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Data;
 using System.Data.Common;
 using DuckDB.NET.Data.Internal;

--- a/DuckDB.NET.Data/Internal/DbTypeMap.cs
+++ b/DuckDB.NET.Data/Internal/DbTypeMap.cs
@@ -25,6 +25,9 @@ internal static class DbTypeMap
         {typeof(ulong), DbType.UInt64},
         {typeof(BigInteger), DbType.VarNumeric},
         {typeof(byte[]), DbType.Binary},
+        {typeof(DateTime), DbType.DateTime},
+        {typeof(DuckDBDateOnly), DbType.Date},
+        {typeof(DuckDBTimeOnly), DbType.Time},
     };
 
 

--- a/DuckDB.NET.Data/Internal/PreparedStatement.cs
+++ b/DuckDB.NET.Data/Internal/PreparedStatement.cs
@@ -25,6 +25,9 @@ internal sealed class PreparedStatement : IDisposable
         { DbType.String, BindString },
         { DbType.VarNumeric, BindHugeInt },
         { DbType.Binary, BindBlob },
+        { DbType.Date, BindDateOnly },
+        { DbType.Time, BindTimeOnly },
+        { DbType.DateTime, BindTimestamp }
     };
 
     private readonly DuckDBPreparedStatement statement;
@@ -93,8 +96,9 @@ internal sealed class PreparedStatement : IDisposable
         {
             throw new InvalidOperationException($"Unable to bind value of type {parameter.DbType}.");
         }
-
+            
         var result = binder(preparedStatement, index, parameter.Value);
+
         if (!result.IsSuccess())
         {
             var errorMessage = NativeMethods.PreparedStatements.DuckDBPrepareError(preparedStatement).ToManagedString(false);
@@ -152,6 +156,25 @@ internal sealed class PreparedStatement : IDisposable
     {
         var bytes = (byte[])value;
         return NativeMethods.PreparedStatements.DuckDBBindBlob(preparedStatement, index, bytes, bytes.LongLength);
+    }
+    
+    private static DuckDBState BindDateOnly(DuckDBPreparedStatement preparedStatement, long index, object value)
+    {
+        var date = NativeMethods.DateTime.DuckDBToDate((DuckDBDateOnly)value);
+        return NativeMethods.PreparedStatements.DuckDBBindDate(preparedStatement, index, date);
+    }
+    
+    private static DuckDBState BindTimeOnly(DuckDBPreparedStatement preparedStatement, long index, object value)
+    {
+        var time = NativeMethods.DateTime.DuckDBToTime((DuckDBTimeOnly)value);
+        return NativeMethods.PreparedStatements.DuckDBBindTime(preparedStatement, index, time);
+    }
+    
+    private static DuckDBState BindTimestamp(DuckDBPreparedStatement preparedStatement, long index, object value)
+    {
+        var timestamp = DuckDBTimestamp.FromDateTime((DateTime) value);
+        var timestampStruct = NativeMethods.DateTime.DuckDBToTimestamp(timestamp);
+        return NativeMethods.PreparedStatements.DuckDBBindTimestamp(preparedStatement, index, timestampStruct);
     }
 
     public void Dispose()

--- a/DuckDB.NET.Test/Parameters/DateTests.cs
+++ b/DuckDB.NET.Test/Parameters/DateTests.cs
@@ -1,0 +1,80 @@
+using System;
+using DuckDB.NET.Data;
+using FluentAssertions;
+using Xunit;
+
+namespace DuckDB.NET.Test.Parameters;
+
+public class DateTests
+{
+    [Theory]
+    [InlineData(1992, 09, 20)]
+    [InlineData(2022, 05, 04)]
+    [InlineData(2022, 04, 05)]
+    public void QueryScalarTest(int year, int mon, int day)
+    {
+        using var connection = new DuckDBConnection(DuckDBConnectionStringBuilder.InMemoryConnectionString);
+        connection.Open();
+
+        using var cmd = connection.CreateCommand();
+        cmd.CommandText = $"SELECT DATE '{year}-{mon}-{day}';";
+
+        var scalar = cmd.ExecuteScalar();
+
+        scalar.Should().BeOfType<DuckDBDateOnly>();
+
+        var dateOnly = (DuckDBDateOnly) scalar;
+
+        dateOnly.Year.Should().Be(year);
+        dateOnly.Month.Should().Be((byte)mon);
+        dateOnly.Day.Should().Be((byte)day);
+
+        var dateTime = dateOnly.ToDateTime();
+        dateTime.Year.Should().Be(year);
+        dateTime.Month.Should().Be(mon);
+        dateTime.Day.Should().Be(day);
+        dateTime.Hour.Should().Be(0);
+        dateTime.Minute.Should().Be(0);
+        dateTime.Second.Should().Be(0);
+
+        var convertedValue = (DateTime) dateOnly;
+        convertedValue.Should().Be(dateTime);
+    }
+    
+    [Theory]
+    [InlineData(1992, 09, 20)]
+    [InlineData(2022, 05, 04)]
+    [InlineData(2022, 04, 05)]
+    public void BindWithCastTest(int year, int mon, int day)
+    {
+        using var connection = new DuckDBConnection(DuckDBConnectionStringBuilder.InMemoryConnectionString);
+        connection.Open();
+        
+        var expectedValue = new DateTime(year, mon, day);
+        
+        using var cmd = connection.CreateCommand();
+        cmd.CommandText = "SELECT ?;";
+        cmd.Parameters.Add(new DuckDBParameter((DuckDBDateOnly)expectedValue));
+
+        var scalar = cmd.ExecuteScalar();
+
+        scalar.Should().BeOfType<DuckDBDateOnly>();
+
+        var dateOnly = (DuckDBDateOnly) scalar;
+
+        dateOnly.Year.Should().Be(year);
+        dateOnly.Month.Should().Be((byte)mon);
+        dateOnly.Day.Should().Be((byte)day);
+
+        var dateTime = dateOnly.ToDateTime();
+        dateTime.Year.Should().Be(year);
+        dateTime.Month.Should().Be(mon);
+        dateTime.Day.Should().Be(day);
+        dateTime.Hour.Should().Be(0);
+        dateTime.Minute.Should().Be(0);
+        dateTime.Second.Should().Be(0);
+
+        var convertedValue = (DateTime) dateOnly;
+        convertedValue.Should().Be(dateTime);
+    }
+}

--- a/DuckDB.NET.Test/Parameters/TimeTests.cs
+++ b/DuckDB.NET.Test/Parameters/TimeTests.cs
@@ -1,0 +1,85 @@
+using System;
+using DuckDB.NET.Data;
+using FluentAssertions;
+using Xunit;
+
+namespace DuckDB.NET.Test.Parameters;
+
+public class TimeTests
+{
+    [Theory]
+    [InlineData(12, 15, 17, 350)]
+    [InlineData(12, 17, 15, 450)]
+    [InlineData(18, 15, 17, 125)]
+    public void QueryScalarTest(int hour, int minute, int second, int millisecond)
+    {
+        using var connection = new DuckDBConnection(DuckDBConnectionStringBuilder.InMemoryConnectionString);
+        connection.Open();
+
+        using var cmd = connection.CreateCommand();
+        cmd.CommandText = $"SELECT TIME '{hour}:{minute}:{second}.{millisecond:000000}';";
+
+        var scalar = cmd.ExecuteScalar();
+
+        scalar.Should().BeOfType<DuckDBTimeOnly>();
+
+        var timeOnly = (DuckDBTimeOnly) scalar;
+
+        timeOnly.Hour.Should().Be((byte)hour);
+        timeOnly.Min.Should().Be((byte)minute);
+        timeOnly.Sec.Should().Be((byte)second);
+        timeOnly.Msec.Should().Be(millisecond);
+
+        var dateTime = timeOnly.ToDateTime();
+        dateTime.Year.Should().Be(DateTime.MinValue.Year);
+        dateTime.Month.Should().Be(DateTime.MinValue.Month);
+        dateTime.Day.Should().Be(DateTime.MinValue.Day);
+        dateTime.Hour.Should().Be(hour);
+        dateTime.Minute.Should().Be(minute);
+        dateTime.Second.Should().Be(second);
+        dateTime.Millisecond.Should().Be(millisecond);
+
+        var convertedValue = (DateTime) timeOnly;
+        convertedValue.Should().Be(dateTime);
+    }
+    
+    [Theory]
+    [InlineData(12, 15, 17, 350)]
+    [InlineData(12, 17, 15, 450)]
+    [InlineData(18, 15, 17, 125)]
+    public void BindWithCastTest(int hour, int minute, int second, int millisecond)
+    {
+        using var connection = new DuckDBConnection(DuckDBConnectionStringBuilder.InMemoryConnectionString);
+        connection.Open();
+        
+        var expectedValue = new DateTime(DateTime.MinValue.Year, DateTime.MinValue.Month, DateTime.MinValue.Day,
+            hour, minute, second, millisecond);
+        
+        using var cmd = connection.CreateCommand();
+        cmd.CommandText = "SELECT ?;";
+        cmd.Parameters.Add(new DuckDBParameter((DuckDBTimeOnly)expectedValue));
+
+        var scalar = cmd.ExecuteScalar();
+
+        scalar.Should().BeOfType<DuckDBTimeOnly>();
+
+        var timeOnly = (DuckDBTimeOnly) scalar;
+
+        timeOnly.Hour.Should().Be((byte)hour);
+        timeOnly.Min.Should().Be((byte)minute);
+        timeOnly.Sec.Should().Be((byte)second);
+        timeOnly.Msec.Should().Be(millisecond);
+
+        var dateTime = timeOnly.ToDateTime();
+        dateTime.Year.Should().Be(DateTime.MinValue.Year);
+        dateTime.Month.Should().Be(DateTime.MinValue.Month);
+        dateTime.Day.Should().Be(DateTime.MinValue.Day);
+        dateTime.Hour.Should().Be(hour);
+        dateTime.Minute.Should().Be(minute);
+        dateTime.Second.Should().Be(second);
+        dateTime.Millisecond.Should().Be(millisecond);
+
+        var convertedValue = (DateTime) timeOnly;
+        convertedValue.Should().Be(dateTime);
+    }
+}

--- a/DuckDB.NET.Test/Parameters/TimestampTests.cs
+++ b/DuckDB.NET.Test/Parameters/TimestampTests.cs
@@ -1,0 +1,74 @@
+using System;
+using DuckDB.NET.Data;
+using FluentAssertions;
+using Xunit;
+
+namespace DuckDB.NET.Test.Parameters;
+
+public class TimestampTests
+{
+    
+    [Theory]
+    [InlineData(1992, 09, 20, 12, 15, 17, 350)]
+    [InlineData(2022, 05, 04, 12, 17, 15, 450)]
+    [InlineData(2022, 04, 05, 18, 15, 17, 125)]
+    public void QueryScalarTest(int year, int mon, int day, int hour, int minute, int second, int millisecond)
+    {
+        using var connection = new DuckDBConnection(DuckDBConnectionStringBuilder.InMemoryConnectionString);
+        connection.Open();
+        
+        var expectedValue = new DateTime(year, mon, day, hour, minute, second, millisecond);
+        
+        using var cmd = connection.CreateCommand();
+        cmd.CommandText = $"SELECT TIMESTAMP '{year}-{mon}-{day} {hour}:{minute}:{second}.{millisecond:000000}';";
+        
+        var scalar = cmd.ExecuteScalar();
+
+        scalar.Should().BeOfType<DateTime>();
+
+        var receivedTime = (DateTime) scalar;
+
+        receivedTime.Year.Should().Be(year);
+        receivedTime.Month.Should().Be(mon);
+        receivedTime.Day.Should().Be(day);
+        receivedTime.Hour.Should().Be(hour);
+        receivedTime.Minute.Should().Be(minute);
+        receivedTime.Second.Should().Be(second);
+        receivedTime.Millisecond.Should().Be(millisecond);
+
+        receivedTime.Should().Be(expectedValue);
+    }
+    
+    
+    [Theory]
+    [InlineData(1992, 09, 20, 12, 15, 17, 350)]
+    [InlineData(2022, 05, 04, 12, 17, 15, 450)]
+    [InlineData(2022, 04, 05, 18, 15, 17, 125)]
+    public void BindTest(int year, int mon, int day, int hour, int minute, int second, int millisecond)
+    {
+        using var connection = new DuckDBConnection(DuckDBConnectionStringBuilder.InMemoryConnectionString);
+        connection.Open();
+        
+        var expectedValue = new DateTime(year, mon, day, hour, minute, second, millisecond);
+        
+        using var cmd = connection.CreateCommand();
+        cmd.CommandText = "SELECT ?;";
+        cmd.Parameters.Add(new DuckDBParameter(expectedValue));
+
+        var scalar = cmd.ExecuteScalar();
+
+        scalar.Should().BeOfType<DateTime>();
+
+        var receivedTime = (DateTime) scalar;
+
+        receivedTime.Year.Should().Be(year);
+        receivedTime.Month.Should().Be(mon);
+        receivedTime.Day.Should().Be(day);
+        receivedTime.Hour.Should().Be(hour);
+        receivedTime.Minute.Should().Be(minute);
+        receivedTime.Second.Should().Be(second);
+        receivedTime.Millisecond.Should().Be(millisecond);
+
+        receivedTime.Should().Be(expectedValue);
+    }
+}

--- a/DuckDB.NET/DuckDBDateOnly.cs
+++ b/DuckDB.NET/DuckDBDateOnly.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Runtime.InteropServices;
+
+namespace DuckDB.NET
+{
+    [StructLayout(LayoutKind.Sequential)]
+    public struct DuckDBDateOnly
+    {
+        public int Year { get; set; }
+
+        public byte Month { get; set; }
+
+        public byte Day { get; set; }
+
+        internal static readonly DuckDBDateOnly MinValue = FromDateTime(DateTime.MinValue);
+        
+        public static DuckDBDateOnly FromDateTime(DateTime dateTime)
+        {
+            return new DuckDBDateOnly {
+                Day = (byte)dateTime.Day,
+                Month = (byte)dateTime.Month,
+                Year = dateTime.Year
+            };
+        }
+        
+        public DateTime ToDateTime()
+            => new DateTime(Year, Month, Day);
+        
+        public static explicit operator DateTime(DuckDBDateOnly dateOnly) => dateOnly.ToDateTime();
+        public static explicit operator DuckDBDateOnly(DateTime dateTime) => FromDateTime(dateTime);
+    }
+}

--- a/DuckDB.NET/DuckDBNativeObjects.cs
+++ b/DuckDB.NET/DuckDBNativeObjects.cs
@@ -79,31 +79,22 @@ namespace DuckDB.NET
         }
     }
 
+    [StructLayout(LayoutKind.Sequential)]
     public struct DuckDBDate
     {
-        public int Year { get; }
-
-        public byte Month { get; }
-
-        public byte Day { get; }
+        public int Days { get; set; }
     }
 
+    [StructLayout(LayoutKind.Sequential)]
     public struct DuckDBTime
     {
-        public byte Hour { get; }
-
-        public byte Min { get; }
-
-        public byte Sec { get; }
-
-        public short Msec { get; }
+        public long Micros { get; set; }
     }
 
-    public struct DuckDBTimestamp
+    [StructLayout(LayoutKind.Sequential)]
+    public struct DuckDBTimestampStruct
     {
-        public DuckDBDate Date { get; }
-
-        public DuckDBTime Time { get; }
+        public long Micros { get; set; }
     }
 
     [StructLayout(LayoutKind.Sequential)]

--- a/DuckDB.NET/DuckDBTimeOnly.cs
+++ b/DuckDB.NET/DuckDBTimeOnly.cs
@@ -1,0 +1,36 @@
+using System;
+using System.Runtime.InteropServices;
+
+namespace DuckDB.NET
+{
+    [StructLayout(LayoutKind.Sequential)]
+    public struct DuckDBTimeOnly
+    {
+        public byte Hour { get; set; }
+
+        public byte Min { get; set; }
+
+        public byte Sec { get; set; }
+
+        public int Msec { get; set; }
+        
+        public DateTime ToDateTime()
+        {
+            var date = DuckDBDateOnly.MinValue;
+            return new DateTime(date.Year, date.Month, date.Day, Hour, Min, Sec, Msec);
+        }
+    
+        public static DuckDBTimeOnly FromDateTime(DateTime dateTime)
+        {
+            return new DuckDBTimeOnly {
+                Hour = (byte)dateTime.Hour,
+                Min = (byte)dateTime.Minute,
+                Sec = (byte)dateTime.Second,
+                Msec = dateTime.Millisecond
+            };
+        }
+    
+        public static explicit operator DateTime(DuckDBTimeOnly timeOnly) => timeOnly.ToDateTime();
+        public static explicit operator DuckDBTimeOnly(DateTime dateTime) => FromDateTime(dateTime);
+    }
+}

--- a/DuckDB.NET/DuckDBTimestamp.cs
+++ b/DuckDB.NET/DuckDBTimestamp.cs
@@ -1,0 +1,33 @@
+using System;
+using System.Runtime.InteropServices;
+
+namespace DuckDB.NET
+{
+    [StructLayout(LayoutKind.Sequential)]
+    public struct DuckDBTimestamp
+    {
+        public DuckDBDateOnly Date { get; set; }
+        public DuckDBTimeOnly Time { get; set; }
+        
+        public DateTime ToDateTime()
+        {
+            return new DateTime(
+                Date.Year,
+                Date.Month,
+                Date.Day,
+                Time.Hour,
+                Time.Min,
+                Time.Sec,
+                Time.Msec
+            );
+        }
+
+        public static DuckDBTimestamp FromDateTime(DateTime dateTime)
+        {
+            return new DuckDBTimestamp {
+                Date = DuckDBDateOnly.FromDateTime(dateTime),
+                Time = DuckDBTimeOnly.FromDateTime(dateTime)
+            };
+        }
+    }
+}

--- a/DuckDB.NET/NativeMethods.cs
+++ b/DuckDB.NET/NativeMethods.cs
@@ -127,6 +127,15 @@ namespace DuckDB.NET
 
             [DllImport(DuckDbLibrary, CallingConvention = CallingConvention.Cdecl, EntryPoint = "duckdb_value_blob")]
             public static extern DuckDBBlob DuckDBValueBlob([In, Out] DuckDBResult result, long col, long row);
+            
+            [DllImport(DuckDbLibrary, CallingConvention = CallingConvention.Cdecl, EntryPoint = "duckdb_value_date")]
+            public static extern DuckDBDate DuckDbValueDate([In, Out] DuckDBResult result, long col, long row);
+            
+            [DllImport(DuckDbLibrary, CallingConvention = CallingConvention.Cdecl, EntryPoint = "duckdb_value_time")]
+            public static extern DuckDBTime DuckDbValueTime([In, Out] DuckDBResult result, long col, long row);
+            
+            [DllImport(DuckDbLibrary, CallingConvention = CallingConvention.Cdecl, EntryPoint = "duckdb_value_timestamp")]
+            public static extern DuckDBTimestampStruct DuckDbValueTimestamp([In, Out] DuckDBResult result, long col, long row);
         }
 
         public static class PreparedStatements
@@ -194,6 +203,15 @@ namespace DuckDB.NET
             [DllImport(DuckDbLibrary, CallingConvention = CallingConvention.Cdecl, EntryPoint = "duckdb_bind_null")]
             public static extern DuckDBState DuckDBBindNull(DuckDBPreparedStatement preparedStatement, long index);
 
+            [DllImport(DuckDbLibrary, CallingConvention = CallingConvention.Cdecl, EntryPoint = "duckdb_bind_date")]
+            public static extern DuckDBState DuckDBBindDate(DuckDBPreparedStatement preparedStatement, long index, DuckDBDate val);
+            
+            [DllImport(DuckDbLibrary, CallingConvention = CallingConvention.Cdecl, EntryPoint = "duckdb_bind_time")]
+            public static extern DuckDBState DuckDBBindTime(DuckDBPreparedStatement preparedStatement, long index, DuckDBTime val);
+            
+            [DllImport(DuckDbLibrary, CallingConvention = CallingConvention.Cdecl, EntryPoint = "duckdb_bind_timestamp")]
+            public static extern DuckDBState DuckDBBindTimestamp(DuckDBPreparedStatement preparedStatement, long index, DuckDBTimestampStruct val);
+            
             [DllImport(DuckDbLibrary, CallingConvention = CallingConvention.Cdecl, EntryPoint = "duckdb_execute_prepared")]
             public static extern DuckDBState DuckDBExecutePrepared(DuckDBPreparedStatement preparedStatement, [In, Out] DuckDBResult result);
         }
@@ -259,6 +277,27 @@ namespace DuckDB.NET
         {
             [DllImport(DuckDbLibrary, CallingConvention = CallingConvention.Cdecl, EntryPoint = "duckdb_free")]
             public static extern void DuckDBFree(IntPtr ptr);
+        }
+
+        public static class DateTime
+        {
+            [DllImport(DuckDbLibrary, CallingConvention = CallingConvention.Cdecl, EntryPoint = "duckdb_from_date")]
+            public static extern DuckDBDateOnly DuckDBFromDate(DuckDBDate date);
+            
+            [DllImport(DuckDbLibrary, CallingConvention = CallingConvention.Cdecl, EntryPoint = "duckdb_to_date")]
+            public static extern DuckDBDate DuckDBToDate(DuckDBDateOnly dateStruct);
+            
+            [DllImport(DuckDbLibrary, CallingConvention = CallingConvention.Cdecl, EntryPoint = "duckdb_from_time")]
+            public static extern DuckDBTimeOnly DuckDBFromTime(DuckDBTime date);
+            
+            [DllImport(DuckDbLibrary, CallingConvention = CallingConvention.Cdecl, EntryPoint = "duckdb_to_time")]
+            public static extern DuckDBTime DuckDBToTime(DuckDBTimeOnly dateStruct);
+            
+            [DllImport(DuckDbLibrary, CallingConvention = CallingConvention.Cdecl, EntryPoint = "duckdb_from_timestamp")]
+            public static extern DuckDBTimestamp DuckDBFromTimestamp(DuckDBTimestampStruct date);
+            
+            [DllImport(DuckDbLibrary, CallingConvention = CallingConvention.Cdecl, EntryPoint = "duckdb_to_timestamp")]
+            public static extern DuckDBTimestampStruct DuckDBToTimestamp(DuckDBTimestamp dateStruct);
         }
     }
 }


### PR DESCRIPTION
Hi!
This pull requests brings support for time-related columns: TIME, DATE and TIMESTAMP. For TIMESTAMP columns we use DateTime. However, because TimeOnly and DateOnly types are only available since .net 6, we use our own types that can be converted to and from DateTime. 

Fix #45 