### PR TITLE
Fix tests for DuckDB v5

### DIFF
--- a/DuckDB.NET.Test/Parameters/ParameterCollectionTests.cs
+++ b/DuckDB.NET.Test/Parameters/ParameterCollectionTests.cs
@@ -139,11 +139,14 @@ public class ParameterCollectionTests
         var command = connection.CreateCommand();
         command.CommandText = "CREATE TABLE ParametersTestKeyValue (KEY INTEGER, VALUE TEXT)";
         command.ExecuteNonQuery();
+        command.CommandText = "INSERT INTO ParametersTestKeyValue (KEY, VALUE) VALUES (42, 'test string');";
+        command.ExecuteNonQuery();
 
         command.CommandText = queryStatement;
         command.Parameters.Add(new DuckDBParameter("param1", 42));
         command.Parameters.Add(new DuckDBParameter("param2", "hello"));
-        command.ExecuteNonQuery();
+        var affectedRows = command.ExecuteNonQuery();
+        affectedRows.Should().NotBe(0);
     }
 
     [Theory]
@@ -159,6 +162,8 @@ public class ParameterCollectionTests
 
         var command = connection.CreateCommand();
         command.CommandText = "CREATE TABLE ParametersTestInvalidOrderKeyValue (KEY INTEGER, VALUE TEXT)";
+        command.ExecuteNonQuery();
+        command.CommandText = "INSERT INTO ParametersTestInvalidOrderKeyValue (KEY, VALUE) VALUES (42, 'test string');";
         command.ExecuteNonQuery();
 
         command.CommandText = queryStatement;


### PR DESCRIPTION
We now have failing builds. The reason is that the tests with UPDATE statements and invalid parameter values are failing. Apparently, that is because DuckDB does not execute UPDATE statements on empty tables. 