### PR TITLE
Fix null handling

### DIFF
--- a/DuckDB.NET.Data/Extensions/ObjectExtension.cs
+++ b/DuckDB.NET.Data/Extensions/ObjectExtension.cs
@@ -1,0 +1,10 @@
+#nullable enable
+using System;
+
+namespace DuckDB.NET.Data.Extensions;
+
+internal static class NullExtension
+{
+    public static bool IsNull(this object? value)
+        => value is null or DBNull;
+}

--- a/DuckDB.NET.Data/Internal/DbTypeMap.cs
+++ b/DuckDB.NET.Data/Internal/DbTypeMap.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Data;
 using System.Numerics;
+using DuckDB.NET.Data.Extensions;
 
 namespace DuckDB.NET.Data.Internal;
 
@@ -33,9 +34,9 @@ internal static class DbTypeMap
 
     public static DbType GetDbTypeForValue(object value)
     {
-        if (value == null)
+        if (value.IsNull())
         {
-            throw new ArgumentNullException(nameof(value));
+            return DbType.Object;
         }
 
         var type = value.GetType();

--- a/DuckDB.NET.Data/Internal/PreparedStatement.cs
+++ b/DuckDB.NET.Data/Internal/PreparedStatement.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Data;
 using System.Numerics;
+using DuckDB.NET.Data.Extensions;
 
 namespace DuckDB.NET.Data;
 
@@ -86,7 +87,7 @@ internal sealed class PreparedStatement : IDisposable
 
     private static void BindParameter(DuckDBPreparedStatement preparedStatement, long index, DuckDBParameter parameter)
     {
-        if (parameter.Value == null)
+        if (parameter.Value.IsNull())
         {
             NativeMethods.PreparedStatements.DuckDBBindNull(preparedStatement, index);
             return;

--- a/DuckDB.NET.Test/Parameters/ParameterCollectionTests.cs
+++ b/DuckDB.NET.Test/Parameters/ParameterCollectionTests.cs
@@ -27,6 +27,23 @@ public class ParameterCollectionTests
         var scalar = command.ExecuteScalar();
         scalar.Should().Be(42);
     }
+    
+    [Theory]
+    [InlineData("SELECT ?1;")]
+    [InlineData("SELECT ?;")]
+    [InlineData("SELECT $1;")]
+    public void BindSingleValueNullTest(string query)
+    {
+        using var connection = new DuckDBConnection("DataSource=:memory:");
+        connection.Open();
+
+        var command = connection.CreateCommand();
+
+        command.Parameters.Add(new DuckDBParameter("test", null));
+        command.CommandText = query;
+        var scalar = command.ExecuteScalar();
+        scalar.Should().Be(DBNull.Value);
+    }
 
     [Fact]
     public void BindNullValueTest()
@@ -215,6 +232,21 @@ public class ParameterCollectionTests
         dp.Add("param1", "test");
 
         connection.Execute(queryStatement, dp);
+    }
+    
+    [Theory]
+    [InlineData("SELECT ?1;")]
+    [InlineData("SELECT ?;")]
+    [InlineData("SELECT $1;")]
+    public void BindSingleValueDapperNullTest(string query)
+    {
+        using var connection = new DuckDBConnection("DataSource=:memory:");
+        connection.Open();
+
+        var parameters = new DynamicParameters();
+        parameters.Add("test", null);
+        var scalar = connection.QuerySingle<long?>(query, parameters);
+        scalar.Should().BeNull();
     }
 
     [Theory]


### PR DESCRIPTION
This PR fixes a serious bug with null value handling. We simply were not able to use null values as parameter values. 


I think we should upload a new nuget version, as this bug makes it impossible to use the binding library in some cases.