### PR TITLE
Pack native libraries into DuckDB.NET

### DIFF
--- a/DuckDB.NET.Test/ModuleInit.cs
+++ b/DuckDB.NET.Test/ModuleInit.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.IO;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+#nullable enable
+namespace DuckDB.NET.Test;
+public static class ModuleInit
+{
+	[ModuleInitializer]
+	public static void Init()
+	{
+		if (GetRid() is not { } rid) return;
+		if (NativeLibrary.TryLoad(Path.Join("runtimes", rid, "native", "duckdb"), out _)) return;
+		_ = NativeLibrary.TryLoad(Path.Join("runtimes", rid, "native", "libduckdb"), out _);
+		
+	}
+
+	private static string? GetRid()
+	{
+
+
+		if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+		{
+			return Environment.Is64BitProcess 
+				? "win-x64" 
+				: "win-x86";
+		}
+		
+		else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+		{
+			return RuntimeInformation.ProcessArchitecture switch
+			{
+				Architecture.X64 => "linux-x64",
+				Architecture.Arm64 => "linux-arm64",
+				_ => null,
+			};
+		}
+
+		return null;
+	}
+}

--- a/DuckDB.NET/DownloadNativeLibs.targets
+++ b/DuckDB.NET/DownloadNativeLibs.targets
@@ -1,0 +1,12 @@
+﻿<Project>
+    <Target Name="Downloadnativenatives" Condition="!Exists('$(MSBuildProjectDirectory)\obj\runtimes\$(Rid)\native')">
+        <MakeDir Directories="$(MSBuildProjectDirectory)\obj\runtimes\$(Rid)\native" />
+        <DownloadFile
+                DestinationFolder="$(MSBuildProjectDirectory)\obj\runtimes\$(Rid)" 
+                SourceUrl="$(libUrl)" 
+                DestinationFileName="native.zip"/>
+        <Unzip DestinationFolder="$(MSBuildProjectDirectory)\obj\runtimes\$(Rid)\native" 
+               SourceFiles="$(MSBuildProjectDirectory)\obj\runtimes\$(Rid)\native.zip"/>
+        <Delete Files="$(MSBuildProjectDirectory)\obj\runtimes\$(Rid)\native.zip"/>
+    </Target>
+</Project>

--- a/DuckDB.NET/DuckDB.NET.csproj
+++ b/DuckDB.NET/DuckDB.NET.csproj
@@ -27,6 +27,8 @@
     <Copyright>Copyright © 2020 - 2022 Giorgi Dalakishvili</Copyright>
     <AssemblyVersion>0.4.0.10</AssemblyVersion>
     <FileVersion>0.4.0.10</FileVersion>
+    
+    <RuntimeIdentifiers>win-x86;win-x64;linux-x64;linux-arm64</RuntimeIdentifiers>
   </PropertyGroup>
 
   <ItemGroup>
@@ -43,12 +45,27 @@
       <PackagePath></PackagePath>
     </None>
   </ItemGroup>
-
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
   </ItemGroup>
-
+  
+  <!-- Download and include the native libraries into the nuget package-->
+  <Target Name="DownloadNativeLibs" BeforeTargets="GenerateAdditionalSources">
+    <MSBuild Projects="DownloadNativeLibs.targets" Properties="Rid=win-x86;LibUrl=https://github.com/duckdb/duckdb/releases/download/v0.6.1/libduckdb-windows-i386.zip" />
+    <MSBuild Projects="DownloadNativeLibs.targets" Properties="Rid=win-x64;LibUrl=https://github.com/duckdb/duckdb/releases/download/v0.6.1/libduckdb-windows-amd64.zip" />
+    <MSBuild Projects="DownloadNativeLibs.targets" Properties="Rid=linux-x64;LibUrl=https://github.com/duckdb/duckdb/releases/download/v0.6.1/libduckdb-linux-amd64.zip" />
+    <MSBuild Projects="DownloadNativeLibs.targets" Properties="Rid=linux-arm64;LibUrl=https://github.com/duckdb/duckdb/releases/download/v0.6.1/libduckdb-linux-aarch64.zip" />
+  </Target>
+  <ItemGroup>
+    <None Include="obj\runtimes\**\*">
+      <Visible>false</Visible>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Pack>true</Pack>
+      <PackagePath>\runtimes</PackagePath>
+    </None>
+  </ItemGroup>
+  <!-- End native lib section -->
 </Project>

--- a/DuckDB.NET/DuckDB.NET.csproj
+++ b/DuckDB.NET/DuckDB.NET.csproj
@@ -65,6 +65,7 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Pack>true</Pack>
       <PackagePath>\runtimes</PackagePath>
+      <Link>runtimes\%(RecursiveDir)\%(FileName)%(Extension)</Link>
     </None>
   </ItemGroup>
   <!-- End native lib section -->

--- a/DuckDB.NET/DuckDB.NET.csproj
+++ b/DuckDB.NET/DuckDB.NET.csproj
@@ -59,6 +59,7 @@
     <MSBuild Projects="DownloadNativeLibs.targets" Properties="Rid=win-x64;LibUrl=$(DuckDbArtifactRoot)/libduckdb-windows-amd64.zip" />
     <MSBuild Projects="DownloadNativeLibs.targets" Properties="Rid=linux-x64;LibUrl=$(DuckDbArtifactRoot)/libduckdb-linux-amd64.zip" />
     <MSBuild Projects="DownloadNativeLibs.targets" Properties="Rid=linux-arm64;LibUrl=$(DuckDbArtifactRoot)/libduckdb-linux-aarch64.zip" />
+    <MSBuild Projects="DownloadNativeLibs.targets" Properties="Rid=osx;LibUrl=$(DuckDbArtifactRoot)/libduckdb-osx-universal.zip" />
   </Target>
   <Target Name="CleanNativeLibs" BeforeTargets="Clean" Condition="'$(Configuration)' == 'Release' ">
     <RemoveDir Directories="obj\runtimes" />

--- a/DuckDB.NET/DuckDB.NET.csproj
+++ b/DuckDB.NET/DuckDB.NET.csproj
@@ -29,6 +29,7 @@
     <FileVersion>0.4.0.10</FileVersion>
     
     <RuntimeIdentifiers>win-x86;win-x64;linux-x64;linux-arm64</RuntimeIdentifiers>
+    <DuckDbArtifactRoot>https://github.com/duckdb/duckdb/releases/download/v0.6.1</DuckDbArtifactRoot>
   </PropertyGroup>
 
   <ItemGroup>
@@ -54,10 +55,10 @@
   
   <!-- Download and include the native libraries into the nuget package-->
   <Target Name="DownloadNativeLibs" BeforeTargets="GenerateAdditionalSources" Condition="'$(Configuration)' == 'Release' ">
-    <MSBuild Projects="DownloadNativeLibs.targets" Properties="Rid=win-x86;LibUrl=https://github.com/duckdb/duckdb/releases/download/v0.6.1/libduckdb-windows-i386.zip" />
-    <MSBuild Projects="DownloadNativeLibs.targets" Properties="Rid=win-x64;LibUrl=https://github.com/duckdb/duckdb/releases/download/v0.6.1/libduckdb-windows-amd64.zip" />
-    <MSBuild Projects="DownloadNativeLibs.targets" Properties="Rid=linux-x64;LibUrl=https://github.com/duckdb/duckdb/releases/download/v0.6.1/libduckdb-linux-amd64.zip" />
-    <MSBuild Projects="DownloadNativeLibs.targets" Properties="Rid=linux-arm64;LibUrl=https://github.com/duckdb/duckdb/releases/download/v0.6.1/libduckdb-linux-aarch64.zip" />
+    <MSBuild Projects="DownloadNativeLibs.targets" Properties="Rid=win-x86;LibUrl=$(DuckDbArtifactRoot)/libduckdb-windows-i386.zip" />
+    <MSBuild Projects="DownloadNativeLibs.targets" Properties="Rid=win-x64;LibUrl=$(DuckDbArtifactRoot)/libduckdb-windows-amd64.zip" />
+    <MSBuild Projects="DownloadNativeLibs.targets" Properties="Rid=linux-x64;LibUrl=$(DuckDbArtifactRoot)/libduckdb-linux-amd64.zip" />
+    <MSBuild Projects="DownloadNativeLibs.targets" Properties="Rid=linux-arm64;LibUrl=$(DuckDbArtifactRoot)/libduckdb-linux-aarch64.zip" />
   </Target>
   <Target Name="CleanNativeLibs" BeforeTargets="Clean" Condition="'$(Configuration)' == 'Release' ">
     <RemoveDir Directories="obj\runtimes" />

--- a/DuckDB.NET/DuckDB.NET.csproj
+++ b/DuckDB.NET/DuckDB.NET.csproj
@@ -53,11 +53,14 @@
   </ItemGroup>
   
   <!-- Download and include the native libraries into the nuget package-->
-  <Target Name="DownloadNativeLibs" BeforeTargets="GenerateAdditionalSources">
+  <Target Name="DownloadNativeLibs" BeforeTargets="GenerateAdditionalSources" Condition="'$(Configuration)' == 'Release' ">
     <MSBuild Projects="DownloadNativeLibs.targets" Properties="Rid=win-x86;LibUrl=https://github.com/duckdb/duckdb/releases/download/v0.6.1/libduckdb-windows-i386.zip" />
     <MSBuild Projects="DownloadNativeLibs.targets" Properties="Rid=win-x64;LibUrl=https://github.com/duckdb/duckdb/releases/download/v0.6.1/libduckdb-windows-amd64.zip" />
     <MSBuild Projects="DownloadNativeLibs.targets" Properties="Rid=linux-x64;LibUrl=https://github.com/duckdb/duckdb/releases/download/v0.6.1/libduckdb-linux-amd64.zip" />
     <MSBuild Projects="DownloadNativeLibs.targets" Properties="Rid=linux-arm64;LibUrl=https://github.com/duckdb/duckdb/releases/download/v0.6.1/libduckdb-linux-aarch64.zip" />
+  </Target>
+  <Target Name="CleanNativeLibs" BeforeTargets="Clean" Condition="'$(Configuration)' == 'Release' ">
+    <RemoveDir Directories="obj\runtimes" />
   </Target>
   <ItemGroup>
     <None Include="obj\runtimes\**\*">


### PR DESCRIPTION
This PR will add the native libraries into the nuget package under the `runtimes` folder.