### PR TITLE
Support schema parameter on CreateAppender

### DIFF
--- a/DuckDB.NET.Data/DuckDBConnection.cs
+++ b/DuckDB.NET.Data/DuckDBConnection.cs
@@ -108,10 +108,12 @@ namespace DuckDB.NET.Data
             };
         }
 
-        public DuckDBAppender CreateAppender(string table)
+        public DuckDBAppender CreateAppender(string table) => CreateAppender(null, table);
+
+        public DuckDBAppender CreateAppender(string schema, string table)
         {
             EnsureConnectionOpen();
-            if (NativeMethods.Appender.DuckDBAppenderCreate(NativeConnection, null, table, out var nativeAppender) == DuckDBState.DuckDBError)
+            if (NativeMethods.Appender.DuckDBAppenderCreate(NativeConnection, schema, table, out var nativeAppender) == DuckDBState.DuckDBError)
             {
                 try
                 {


### PR DESCRIPTION
This change is to allow the passing of a schema option on the CreateAppender something supported on the native method but not with the ADO.NET Provider. See issue #94 