### PR TITLE
Add Apple Silicon support

### DIFF
--- a/DuckDB.NET.Test/ModuleInit.cs
+++ b/DuckDB.NET.Test/ModuleInit.cs
@@ -47,7 +47,12 @@ public static class ModuleInit
 
         if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
         {
-            return "osx-x64";
+            return RuntimeInformation.ProcessArchitecture switch
+            {
+                Architecture.X64 => "osx-x64",
+                Architecture.Arm64 => "osx-arm64",
+                _ => null,
+            };
         }
 
         return null;

--- a/DuckDB.NET/Bindings.csproj
+++ b/DuckDB.NET/Bindings.csproj
@@ -18,8 +18,7 @@
     <MSBuild Projects="DownloadNativeLibs.targets" Properties="Rid=win-x64;LibUrl=$(DuckDbArtifactRoot)/libduckdb-windows-amd64.zip" />
     <MSBuild Projects="DownloadNativeLibs.targets" Properties="Rid=linux-x64;LibUrl=$(DuckDbArtifactRoot)/libduckdb-linux-amd64.zip" />
     <MSBuild Projects="DownloadNativeLibs.targets" Properties="Rid=linux-arm64;LibUrl=$(DuckDbArtifactRoot)/libduckdb-linux-aarch64.zip" />
-    <MSBuild Projects="DownloadNativeLibs.targets" Properties="Rid=osx-x64;LibUrl=$(DuckDbArtifactRoot)/libduckdb-osx-universal.zip" />
-    <MSBuild Projects="DownloadNativeLibs.targets" Properties="Rid=osx-arm64;LibUrl=$(DuckDbArtifactRoot)/libduckdb-osx-universal.zip" />
+    <MSBuild Projects="DownloadNativeLibs.targets" Properties="Rid=osx;LibUrl=$(DuckDbArtifactRoot)/libduckdb-osx-universal.zip" />
   </Target>
   <Target Name="CleanNativeLibs" BeforeTargets="Clean" Condition="'$(BuildType)' == 'Full' ">
     <RemoveDir Directories="obj\runtimes" />

--- a/DuckDB.NET/Bindings.csproj
+++ b/DuckDB.NET/Bindings.csproj
@@ -4,7 +4,7 @@
     <Description>DuckDB Bindings for C#.</Description>
     <PackageReleaseNotes>Fix bug when inserting unicode test through appender.</PackageReleaseNotes>
     <RootNamespace>DuckDB.NET</RootNamespace>
-    <RuntimeIdentifiers>win-x86;win-x64;linux-x64;linux-arm64;osx-x64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win-x86;win-x64;linux-x64;linux-arm64;osx-x64,osx-arm64</RuntimeIdentifiers>
     <DuckDbArtifactRoot>https://github.com/duckdb/duckdb/releases/download/v0.7.1</DuckDbArtifactRoot>
   </PropertyGroup>
 
@@ -19,6 +19,7 @@
     <MSBuild Projects="DownloadNativeLibs.targets" Properties="Rid=linux-x64;LibUrl=$(DuckDbArtifactRoot)/libduckdb-linux-amd64.zip" />
     <MSBuild Projects="DownloadNativeLibs.targets" Properties="Rid=linux-arm64;LibUrl=$(DuckDbArtifactRoot)/libduckdb-linux-aarch64.zip" />
     <MSBuild Projects="DownloadNativeLibs.targets" Properties="Rid=osx-x64;LibUrl=$(DuckDbArtifactRoot)/libduckdb-osx-universal.zip" />
+    <MSBuild Projects="DownloadNativeLibs.targets" Properties="Rid=osx-arm64;LibUrl=$(DuckDbArtifactRoot)/libduckdb-osx-universal.zip" />
   </Target>
   <Target Name="CleanNativeLibs" BeforeTargets="Clean" Condition="'$(BuildType)' == 'Full' ">
     <RemoveDir Directories="obj\runtimes" />

--- a/DuckDB.NET/Bindings.csproj
+++ b/DuckDB.NET/Bindings.csproj
@@ -4,7 +4,7 @@
     <Description>DuckDB Bindings for C#.</Description>
     <PackageReleaseNotes>Fix bug when inserting unicode test through appender.</PackageReleaseNotes>
     <RootNamespace>DuckDB.NET</RootNamespace>
-    <RuntimeIdentifiers>win-x86;win-x64;linux-x64;linux-arm64;osx</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win-x86;win-x64;linux-x64;linux-arm64;osx-x64;osx-arm64</RuntimeIdentifiers>
     <DuckDbArtifactRoot>https://github.com/duckdb/duckdb/releases/download/v0.7.1</DuckDbArtifactRoot>
   </PropertyGroup>
 
@@ -18,7 +18,8 @@
     <MSBuild Projects="DownloadNativeLibs.targets" Properties="Rid=win-x64;LibUrl=$(DuckDbArtifactRoot)/libduckdb-windows-amd64.zip" />
     <MSBuild Projects="DownloadNativeLibs.targets" Properties="Rid=linux-x64;LibUrl=$(DuckDbArtifactRoot)/libduckdb-linux-amd64.zip" />
     <MSBuild Projects="DownloadNativeLibs.targets" Properties="Rid=linux-arm64;LibUrl=$(DuckDbArtifactRoot)/libduckdb-linux-aarch64.zip" />
-    <MSBuild Projects="DownloadNativeLibs.targets" Properties="Rid=osx;LibUrl=$(DuckDbArtifactRoot)/libduckdb-osx-universal.zip" />
+    <MSBuild Projects="DownloadNativeLibs.targets" Properties="Rid=osx-x64;LibUrl=$(DuckDbArtifactRoot)/libduckdb-osx-universal.zip" />
+    <MSBuild Projects="DownloadNativeLibs.targets" Properties="Rid=osx-arm64;LibUrl=$(DuckDbArtifactRoot)/libduckdb-osx-universal.zip" />
   </Target>
   <Target Name="CleanNativeLibs" BeforeTargets="Clean" Condition="'$(BuildType)' == 'Full' ">
     <RemoveDir Directories="obj\runtimes" />

--- a/DuckDB.NET/Bindings.csproj
+++ b/DuckDB.NET/Bindings.csproj
@@ -4,7 +4,7 @@
     <Description>DuckDB Bindings for C#.</Description>
     <PackageReleaseNotes>Fix bug when inserting unicode test through appender.</PackageReleaseNotes>
     <RootNamespace>DuckDB.NET</RootNamespace>
-    <RuntimeIdentifiers>win-x86;win-x64;linux-x64;linux-arm64;osx-x64,osx-arm64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win-x86;win-x64;linux-x64;linux-arm64;osx</RuntimeIdentifiers>
     <DuckDbArtifactRoot>https://github.com/duckdb/duckdb/releases/download/v0.7.1</DuckDbArtifactRoot>
   </PropertyGroup>
 
@@ -18,8 +18,7 @@
     <MSBuild Projects="DownloadNativeLibs.targets" Properties="Rid=win-x64;LibUrl=$(DuckDbArtifactRoot)/libduckdb-windows-amd64.zip" />
     <MSBuild Projects="DownloadNativeLibs.targets" Properties="Rid=linux-x64;LibUrl=$(DuckDbArtifactRoot)/libduckdb-linux-amd64.zip" />
     <MSBuild Projects="DownloadNativeLibs.targets" Properties="Rid=linux-arm64;LibUrl=$(DuckDbArtifactRoot)/libduckdb-linux-aarch64.zip" />
-    <MSBuild Projects="DownloadNativeLibs.targets" Properties="Rid=osx-x64;LibUrl=$(DuckDbArtifactRoot)/libduckdb-osx-universal.zip" />
-    <MSBuild Projects="DownloadNativeLibs.targets" Properties="Rid=osx-arm64;LibUrl=$(DuckDbArtifactRoot)/libduckdb-osx-universal.zip" />
+    <MSBuild Projects="DownloadNativeLibs.targets" Properties="Rid=osx;LibUrl=$(DuckDbArtifactRoot)/libduckdb-osx-universal.zip" />
   </Target>
   <Target Name="CleanNativeLibs" BeforeTargets="Clean" Condition="'$(BuildType)' == 'Full' ">
     <RemoveDir Directories="obj\runtimes" />


### PR DESCRIPTION
I'am trying to use the awesome library on my M1 Pro Mac with arm64 but i'am getting System.DllNotFoundException: Unable to load shared library 'duckdb' or one of its dependencies. errors.

It seems that just the osx-arm64 runtime is missing.
This is my attempt to fix this problem and i hope this change is enought and the osx-universal also work on arm64.

Please feel free to correct my small attempt :-)
