### PR TITLE
Ignore unused query parameters

### DIFF
--- a/DuckDB.NET.Data/Internal/PreparedStatement.cs
+++ b/DuckDB.NET.Data/Internal/PreparedStatement.cs
@@ -142,7 +142,7 @@ internal sealed class PreparedStatement : IDisposable
     private static void BindParameters(DuckDBPreparedStatement preparedStatement, DuckDBParameterCollection parameterCollection)
     {
         var expectedParameters = NativeMethods.PreparedStatements.DuckDBParams(preparedStatement);
-        if (expectedParameters != parameterCollection.Count)
+        if (parameterCollection.Count < expectedParameters)
         {
             throw new InvalidOperationException($"Invalid number of parameters. Expected {expectedParameters}, got {parameterCollection.Count}");
         }
@@ -156,15 +156,11 @@ internal sealed class PreparedStatement : IDisposable
                 {
                     BindParameter(preparedStatement, index, param);
                 }
-                else
-                {
-                    throw new InvalidOperationException($"Cannot get parameter '{param.ParameterName}' index.");
-                }
             }
         }
         else
         {
-            for (var i = 0; i < parameterCollection.Count; ++i)
+            for (var i = 0; i < expectedParameters; ++i)
             {
                 var param = parameterCollection[i];
                 BindParameter(preparedStatement, i + 1, param);

--- a/DuckDB.NET.Test/Parameters/ParameterCollectionTests.cs
+++ b/DuckDB.NET.Test/Parameters/ParameterCollectionTests.cs
@@ -9,22 +9,21 @@ using Xunit;
 
 namespace DuckDB.NET.Test.Parameters;
 
-public class ParameterCollectionTests
+public class ParameterCollectionTests : DuckDBTestBase
 {
-    [Theory]
+	public ParameterCollectionTests(DuckDBDatabaseFixture db) : base(db)
+	{
+	}
+
+	[Theory]
     [InlineData("SELECT ?1;")]
     [InlineData("SELECT ?;")]
     [InlineData("SELECT $1;")]
     public void BindSingleValueTest(string query)
     {
-        using var connection = new DuckDBConnection("DataSource=:memory:");
-        connection.Open();
-
-        var command = connection.CreateCommand();
-
-        command.Parameters.Add(new DuckDBParameter("1", 42));
-        command.CommandText = query;
-        var scalar = command.ExecuteScalar();
+        Command.Parameters.Add(new DuckDBParameter("1", 42));
+		Command.CommandText = query;
+        var scalar = Command.ExecuteScalar();
         scalar.Should().Be(42);
     }
     
@@ -34,78 +33,59 @@ public class ParameterCollectionTests
     [InlineData("SELECT $1;")]
     public void BindSingleValueNullTest(string query)
     {
-        using var connection = new DuckDBConnection("DataSource=:memory:");
-        connection.Open();
-
-        var command = connection.CreateCommand();
-
-        command.Parameters.Add(new DuckDBParameter("1", null));
-        command.CommandText = query;
-        var scalar = command.ExecuteScalar();
+		Command.Parameters.Add(new DuckDBParameter("1", null));
+		Command.CommandText = query;
+        var scalar = Command.ExecuteScalar();
         scalar.Should().Be(DBNull.Value);
     }
 
     [Fact]
     public void BindNullValueTest()
     {
-        using var connection = new DuckDBConnection("DataSource=:memory:");
-        connection.Open();
 
-        var command = new DuckDbCommand("Select ?", connection);
-        command.Parameters.Add(new DuckDBParameter());
+        Command.CommandText = "SELECT ?";
+        Command.Parameters.Add(new DuckDBParameter());
 
-        var scalar = command.ExecuteScalar();
+        var scalar = Command.ExecuteScalar();
         scalar.Should().Be(DBNull.Value);
     }
 
     [Fact]
     public void ParameterCountMismatchTest()
     {
-        using var connection = new DuckDBConnection("DataSource=:memory:");
-        connection.Open();
-
-        var command = new DuckDbCommand("Select ?", connection);
-
-        command.Invoking(dbCommand => dbCommand.ExecuteScalar()).Should().Throw<InvalidOperationException>();
+		Command.CommandText = "SELECT ?";
+		Command.Invoking(dbCommand => dbCommand.ExecuteScalar()).Should().Throw<InvalidOperationException>();
     }
 
     [Fact]
     public void PrepareCommandNoOperationTest()
     {
-        using var connection = new DuckDBConnection("DataSource=:memory:");
-        connection.Open();
-
-        var command = new DuckDbCommand("Select ? from nowhere", connection);
-
-        command.Invoking(dbCommand => dbCommand.Prepare()).Should().NotThrow();
+        Command.CommandText = "SELECT ? FROM nowhere";
+		Command.Invoking(dbCommand => dbCommand.Prepare()).Should().NotThrow();
     }
 
     [Fact]
     public void ParameterConstructorTests()
     {
-        using var connection = new DuckDBConnection("DataSource=:memory:");
-        connection.Open();
+        Command.CommandText = "CREATE TABLE ParameterConstructorTests (key INTEGER, value double, State Boolean, ErrorCode Long, value2 float)";
+		Command.ExecuteNonQuery();
 
-        var duckDbCommand = connection.CreateCommand();
-        duckDbCommand.CommandText = "CREATE TABLE ParameterConstructorTests (key INTEGER, value double, State Boolean, ErrorCode Long, value2 float)";
-        duckDbCommand.ExecuteNonQuery();
-
-        duckDbCommand.CommandText = "Insert Into ParameterConstructorTests values (?,?,?,?,?)";
-        duckDbCommand.Parameters.Add(new DuckDBParameter(DbType.Double, 2.4));
-        duckDbCommand.Parameters.Add(new DuckDBParameter(true));
-        duckDbCommand.Parameters.Insert(0, new DuckDBParameter(2));
-        duckDbCommand.Parameters.RemoveAt(2);
-        duckDbCommand.Parameters.AddRange(new List<DuckDBParameter>{new()
+		Command.CommandText = "Insert Into ParameterConstructorTests values (?,?,?,?,?)";
+		Command.Parameters.Add(new DuckDBParameter(DbType.Double, 2.4));
+		Command.Parameters.Add(new DuckDBParameter(true));
+        Command.Parameters.Insert(0, new DuckDBParameter(2));
+		Command.Parameters.RemoveAt(2);
+		Command.Parameters.AddRange(new List<DuckDBParameter>{new()
         {
             Value = true
         }, new(24), new(2.0f)});
 
-        duckDbCommand.ExecuteNonQuery();
+		Command.ExecuteNonQuery();
 
-        duckDbCommand.CommandText = "select * from ParameterConstructorTests";
-        duckDbCommand.Parameters.Clear();
+		Command.CommandText = "select * from ParameterConstructorTests";
+		Command.Parameters.Clear();
 
-        var dataReader = duckDbCommand.ExecuteReader();
+        var dataReader = Command.ExecuteReader();
         dataReader.Read();
 
         dataReader.GetInt32(0).Should().Be(2);
@@ -150,20 +130,17 @@ public class ParameterCollectionTests
     [InlineData("UPDATE ParametersTestKeyValue SET KEY = $1, VALUE = $2;")]
     public void BindMultipleValuesTest(string queryStatement)
     {
-        using var connection = new DuckDBConnection("DataSource=:memory:");
-        using var defer = new Defer(() => connection.Execute("DROP TABLE ParametersTestKeyValue;"));
-        connection.Open();
+        using var defer = new Defer(() => Connection.Execute("DROP TABLE ParametersTestKeyValue;"));
 
-        var command = connection.CreateCommand();
-        command.CommandText = "CREATE TABLE ParametersTestKeyValue (KEY INTEGER, VALUE TEXT)";
-        command.ExecuteNonQuery();
-        command.CommandText = "INSERT INTO ParametersTestKeyValue (KEY, VALUE) VALUES (42, 'test string');";
-        command.ExecuteNonQuery();
+        Command.CommandText = "CREATE TABLE ParametersTestKeyValue (KEY INTEGER, VALUE TEXT)";
+		Command.ExecuteNonQuery();
+		Command.CommandText = "INSERT INTO ParametersTestKeyValue (KEY, VALUE) VALUES (42, 'test string');";
+		Command.ExecuteNonQuery();
 
-        command.CommandText = queryStatement;
-        command.Parameters.Add(new DuckDBParameter("1", 42));
-        command.Parameters.Add(new DuckDBParameter("2", "hello"));
-        var affectedRows = command.ExecuteNonQuery();
+		Command.CommandText = queryStatement;
+		Command.Parameters.Add(new DuckDBParameter("1", 42));
+		Command.Parameters.Add(new DuckDBParameter("2", "hello"));
+        var affectedRows = Command.ExecuteNonQuery();
         affectedRows.Should().NotBe(0);
     }
 
@@ -172,20 +149,17 @@ public class ParameterCollectionTests
     [InlineData("UPDATE ParametersTestKeyValue SET KEY = $key, VALUE = $value;")]
     public void BindMultipleValuesTestNamedParameters(string queryStatement)
     {
-        using var connection = new DuckDBConnection("DataSource=:memory:");
-        using var defer = new Defer(() => connection.Execute("DROP TABLE ParametersTestKeyValue;"));
-        connection.Open();
+        using var defer = new Defer(() => Connection.Execute("DROP TABLE ParametersTestKeyValue;"));
 
-        var command = connection.CreateCommand();
-        command.CommandText = "CREATE TABLE ParametersTestKeyValue (KEY INTEGER, VALUE TEXT)";
-        command.ExecuteNonQuery();
-        command.CommandText = "INSERT INTO ParametersTestKeyValue (KEY, VALUE) VALUES (42, 'test string');";
-        command.ExecuteNonQuery();
+		Command.CommandText = "CREATE TABLE ParametersTestKeyValue (KEY INTEGER, VALUE TEXT)";
+		Command.ExecuteNonQuery();
+		Command.CommandText = "INSERT INTO ParametersTestKeyValue (KEY, VALUE) VALUES (42, 'test string');";
+		Command.ExecuteNonQuery();
 
-        command.CommandText = queryStatement;
-        command.Parameters.Add(new DuckDBParameter("key", 42));
-        command.Parameters.Add(new DuckDBParameter("value", "hello"));
-        var affectedRows = command.ExecuteNonQuery();
+		Command.CommandText = queryStatement;
+		Command.Parameters.Add(new DuckDBParameter("key", 42));
+		Command.Parameters.Add(new DuckDBParameter("value", "hello"));
+        var affectedRows = Command.ExecuteNonQuery();
         affectedRows.Should().NotBe(0);
     }
 
@@ -196,26 +170,23 @@ public class ParameterCollectionTests
     [InlineData("UPDATE ParametersTestInvalidOrderKeyValue SET Key = $2, Value = $1;")]
     public void BindMultipleValuesInvalidOrderTest(string queryStatement)
     {
-        using var connection = new DuckDBConnection("DataSource=:memory:");
-        using var defer = new Defer(() => connection.Execute("DROP TABLE ParametersTestInvalidOrderKeyValue;"));
-        connection.Open();
+        using var defer = new Defer(() => Connection.Execute("DROP TABLE ParametersTestInvalidOrderKeyValue;"));
 
-        var command = connection.CreateCommand();
-        command.CommandText = "CREATE TABLE ParametersTestInvalidOrderKeyValue (KEY INTEGER, VALUE TEXT)";
-        command.ExecuteNonQuery();
-        command.CommandText = "INSERT INTO ParametersTestInvalidOrderKeyValue (KEY, VALUE) VALUES (42, 'test string');";
-        command.ExecuteNonQuery();
+		Command.CommandText = "CREATE TABLE ParametersTestInvalidOrderKeyValue (KEY INTEGER, VALUE TEXT)";
+        Command.ExecuteNonQuery();
+        Command.CommandText = "INSERT INTO ParametersTestInvalidOrderKeyValue (KEY, VALUE) VALUES (42, 'test string');";
+        Command.ExecuteNonQuery();
 
-        command.CommandText = queryStatement;
-        command.Parameters.Add(new DuckDBParameter("param1", 42));
-        command.Parameters.Add(new DuckDBParameter("param2", "hello"));
-        command.Invoking(cmd => cmd.ExecuteNonQuery())
+        Command.CommandText = queryStatement;
+        Command.Parameters.Add(new DuckDBParameter("param1", 42));
+        Command.Parameters.Add(new DuckDBParameter("param2", "hello"));
+        Command.Invoking(cmd => cmd.ExecuteNonQuery())
             .Should().ThrowExactly<DuckDBException>();
 
-        command.Parameters.Clear();
-        command.Parameters.Add(new DuckDBParameter(42));
-        command.Parameters.Add(new DuckDBParameter("hello"));
-        command.Invoking(cmd => cmd.ExecuteNonQuery())
+        Command.Parameters.Clear();
+        Command.Parameters.Add(new DuckDBParameter(42));
+        Command.Parameters.Add(new DuckDBParameter("hello"));
+        Command.Invoking(cmd => cmd.ExecuteNonQuery())
             .Should().ThrowExactly<DuckDBException>();
     }
 
@@ -225,18 +196,16 @@ public class ParameterCollectionTests
     [InlineData("UPDATE DapperParametersObjectBindingTest SET a = ?, b = ?;")]
     public void BindDapperWithObjectTest(string queryStatement)
     {
-        using var connection = new DuckDBConnection("DataSource=:memory:");
-        using var defer = new Defer(() => connection.Execute("DROP TABLE DapperParametersObjectBindingTest;"));
-        connection.Open();
+        using var defer = new Defer(() => Connection.Execute("DROP TABLE DapperParametersObjectBindingTest;"));
 
-        connection.Execute("CREATE TABLE DapperParametersObjectBindingTest (a INTEGER, b TEXT);");
-        connection.Execute("INSERT INTO DapperParametersObjectBindingTest (a, b) VALUES (42, 'test string');");
+        Connection.Execute("CREATE TABLE DapperParametersObjectBindingTest (a INTEGER, b TEXT);");
+        Connection.Execute("INSERT INTO DapperParametersObjectBindingTest (a, b) VALUES (42, 'test string');");
 
         var dp = new DynamicParameters();
         dp.Add("?1", 1);
         dp.Add("?2", "test");
 
-        connection.Execute(queryStatement, dp).Should().BeGreaterOrEqualTo(1);
+        Connection.Execute(queryStatement, dp).Should().BeGreaterOrEqualTo(1);
     }
 
     [Theory]
@@ -245,19 +214,17 @@ public class ParameterCollectionTests
     [InlineData("UPDATE DapperParametersObjectBindingTest SET a = $foo, b = $bar;")]
     public void BindDapperWithObjectTestNamesParameters(string queryStatement)
     {
-        using var connection = new DuckDBConnection("DataSource=:memory:");
-        using var defer = new Defer(() => connection.Execute("DROP TABLE DapperParametersObjectBindingTest;"));
-        connection.Open();
+        using var defer = new Defer(() => Connection.Execute("DROP TABLE DapperParametersObjectBindingTest;"));
 
-        connection.Execute("CREATE TABLE DapperParametersObjectBindingTest (a INTEGER, b TEXT);");
-        connection.Execute("INSERT INTO DapperParametersObjectBindingTest (a, b) VALUES (42, 'test string');");
+        Connection.Execute("CREATE TABLE DapperParametersObjectBindingTest (a INTEGER, b TEXT);");
+        Connection.Execute("INSERT INTO DapperParametersObjectBindingTest (a, b) VALUES (42, 'test string');");
 
         var dp = new DynamicParameters();
         dp.Add("foo", 1);
         dp.Add("bar", "test");
         
-        connection.Execute(queryStatement, dp).Should().BeGreaterOrEqualTo(1);
-        connection.Execute(queryStatement, new { foo = 1, bar = "test" }).Should().BeGreaterOrEqualTo(1, "Passing parameters as object should work");
+        Connection.Execute(queryStatement, dp).Should().BeGreaterOrEqualTo(1);
+        Connection.Execute(queryStatement, new { foo = 1, bar = "test" }).Should().BeGreaterOrEqualTo(1, "Passing parameters as object should work");
     }
 
     [Theory]
@@ -268,17 +235,15 @@ public class ParameterCollectionTests
     [InlineData("UPDATE DapperParametersDynamicParamsBindingTest SET a = $1, b = $2;")]
     public void BindDapperDynamicParamsOnlyTest(string queryStatement)
     {
-        using var connection = new DuckDBConnection("DataSource=:memory:");
-        using var defer = new Defer(() => connection.Execute("DROP TABLE DapperParametersDynamicParamsBindingTest;"));
-        connection.Open();
+        using var defer = new Defer(() => Connection.Execute("DROP TABLE DapperParametersDynamicParamsBindingTest;"));
 
-        connection.Execute("CREATE TABLE DapperParametersDynamicParamsBindingTest (a INTEGER, b TEXT);");
+        Connection.Execute("CREATE TABLE DapperParametersDynamicParamsBindingTest (a INTEGER, b TEXT);");
 
         var dp = new DynamicParameters();
         dp.Add("1", 1);
         dp.Add("2", "test");
 
-        connection.Execute(queryStatement, dp).Should().BeLessOrEqualTo(1);
+        Connection.Execute(queryStatement, dp).Should().BeLessOrEqualTo(1);
     }
     
     [Theory]
@@ -287,12 +252,9 @@ public class ParameterCollectionTests
     [InlineData("SELECT $1;")]
     public void BindSingleValueDapperNullTest(string query)
     {
-        using var connection = new DuckDBConnection("DataSource=:memory:");
-        connection.Open();
-
         var parameters = new DynamicParameters();
         parameters.Add("1", null);
-        var scalar = connection.QuerySingle<long?>(query, parameters);
+        var scalar = Connection.QuerySingle<long?>(query, parameters);
         scalar.Should().BeNull();
     }
 
@@ -304,39 +266,40 @@ public class ParameterCollectionTests
     [InlineData("UPDATE DapperParametersObjectBindingFailTest SET a = $1, b = $2;")]
     public void BindDapperObjectFailuresTest(string queryStatement)
     {
-        using var connection = new DuckDBConnection("DataSource=:memory:");
-        using var defer = new Defer(() => connection.Execute("DROP TABLE DapperParametersObjectBindingFailTest;"));
-        connection.Open();
+        using var defer = new Defer(() => Connection.Execute("DROP TABLE DapperParametersObjectBindingFailTest;"));
 
-        connection.Execute("CREATE TABLE DapperParametersObjectBindingFailTest (a INTEGER, b TEXT);");
+        Connection.Execute("CREATE TABLE DapperParametersObjectBindingFailTest (a INTEGER, b TEXT);");
 
-        connection.Invoking(con => con.Execute(queryStatement, new { param1 = 1, param2 = "hello" }))
+        Connection.Invoking(con => con.Execute(queryStatement, new { param1 = 1, param2 = "hello" }))
             .Should().ThrowExactly<InvalidOperationException>();
     }
 
-    [Fact]
+	[Fact]
+	public void BindUnreferencedNamedParameterInParameterlessQueryTest()
+	{
+		Command.CommandText = "SELECT 42";
+		Command.Parameters.Add(new DuckDBParameter("unused", 24));
+		var scalar = Command.ExecuteScalar();
+		scalar.Should().Be(42);
+	}
+
+
+	[Fact]
     public void BindUnreferencedNamedParameterTest()
     {
-        using var connection = new DuckDBConnection("DataSource=:memory:");
-        connection.Open();
-
-        var command = connection.CreateCommand();
-        command.CommandText = "SELECT 1";
-        command.Parameters.Add(new DuckDBParameter("unused", 42));
-        var scalar = command.ExecuteScalar();
-        scalar.Should().Be(1);
+		Command.CommandText = "SELECT $used";
+		Command.Parameters.Add(new DuckDBParameter("unused", 24));
+		Command.Parameters.Add(new DuckDBParameter("used", 42));
+		var scalar = Command.ExecuteScalar();
+        scalar.Should().Be(42);
     }
 
     [Fact]
     public void BindUnreferencedPositionalParameterTest()
     {
-        using var connection = new DuckDBConnection("DataSource=:memory:");
-        connection.Open();
-
-        var command = connection.CreateCommand();
-        command.CommandText = "SELECT 1";
-        command.Parameters.Add(new DuckDBParameter(42));    // unused
-        var scalar = command.ExecuteScalar();
+		Command.CommandText = "SELECT 1";
+		Command.Parameters.Add(new DuckDBParameter(42));    // unused
+        var scalar = Command.ExecuteScalar();
         scalar.Should().Be(1);
     }
 }

--- a/DuckDB.NET.Test/Parameters/ParameterCollectionTests.cs
+++ b/DuckDB.NET.Test/Parameters/ParameterCollectionTests.cs
@@ -11,30 +11,30 @@ namespace DuckDB.NET.Test.Parameters;
 
 public class ParameterCollectionTests : DuckDBTestBase
 {
-	public ParameterCollectionTests(DuckDBDatabaseFixture db) : base(db)
-	{
-	}
+    public ParameterCollectionTests(DuckDBDatabaseFixture db) : base(db)
+    {
+    }
 
-	[Theory]
+    [Theory]
     [InlineData("SELECT ?1;")]
     [InlineData("SELECT ?;")]
     [InlineData("SELECT $1;")]
     public void BindSingleValueTest(string query)
     {
         Command.Parameters.Add(new DuckDBParameter("1", 42));
-		Command.CommandText = query;
+        Command.CommandText = query;
         var scalar = Command.ExecuteScalar();
         scalar.Should().Be(42);
     }
-    
+
     [Theory]
     [InlineData("SELECT ?1;")]
     [InlineData("SELECT ?;")]
     [InlineData("SELECT $1;")]
     public void BindSingleValueNullTest(string query)
     {
-		Command.Parameters.Add(new DuckDBParameter("1", null));
-		Command.CommandText = query;
+        Command.Parameters.Add(new DuckDBParameter("1", null));
+        Command.CommandText = query;
         var scalar = Command.ExecuteScalar();
         scalar.Should().Be(DBNull.Value);
     }
@@ -53,37 +53,37 @@ public class ParameterCollectionTests : DuckDBTestBase
     [Fact]
     public void ParameterCountMismatchTest()
     {
-		Command.CommandText = "SELECT ?";
-		Command.Invoking(dbCommand => dbCommand.ExecuteScalar()).Should().Throw<InvalidOperationException>();
+        Command.CommandText = "SELECT ?";
+        Command.Invoking(dbCommand => dbCommand.ExecuteScalar()).Should().Throw<InvalidOperationException>();
     }
 
     [Fact]
     public void PrepareCommandNoOperationTest()
     {
         Command.CommandText = "SELECT ? FROM nowhere";
-		Command.Invoking(dbCommand => dbCommand.Prepare()).Should().NotThrow();
+        Command.Invoking(dbCommand => dbCommand.Prepare()).Should().NotThrow();
     }
 
     [Fact]
     public void ParameterConstructorTests()
     {
         Command.CommandText = "CREATE TABLE ParameterConstructorTests (key INTEGER, value double, State Boolean, ErrorCode Long, value2 float)";
-		Command.ExecuteNonQuery();
+        Command.ExecuteNonQuery();
 
-		Command.CommandText = "Insert Into ParameterConstructorTests values (?,?,?,?,?)";
-		Command.Parameters.Add(new DuckDBParameter(DbType.Double, 2.4));
-		Command.Parameters.Add(new DuckDBParameter(true));
+        Command.CommandText = "Insert Into ParameterConstructorTests values (?,?,?,?,?)";
+        Command.Parameters.Add(new DuckDBParameter(DbType.Double, 2.4));
+        Command.Parameters.Add(new DuckDBParameter(true));
         Command.Parameters.Insert(0, new DuckDBParameter(2));
-		Command.Parameters.RemoveAt(2);
-		Command.Parameters.AddRange(new List<DuckDBParameter>{new()
+        Command.Parameters.RemoveAt(2);
+        Command.Parameters.AddRange(new List<DuckDBParameter>{new()
         {
             Value = true
         }, new(24), new(2.0f)});
 
-		Command.ExecuteNonQuery();
+        Command.ExecuteNonQuery();
 
-		Command.CommandText = "select * from ParameterConstructorTests";
-		Command.Parameters.Clear();
+        Command.CommandText = "select * from ParameterConstructorTests";
+        Command.Parameters.Clear();
 
         var dataReader = Command.ExecuteReader();
         dataReader.Read();
@@ -113,7 +113,7 @@ public class ParameterCollectionTests : DuckDBTestBase
         parameters[0] = duckDBParameterLong;
         parameters.Contains(duckDBParameterLong).Should().BeTrue();
 
-        var duckDBParameterFloat = new DuckDBParameter("param1",2f);
+        var duckDBParameterFloat = new DuckDBParameter("param1", 2f);
         parameters["param0"] = duckDBParameterFloat;
         parameters["param1"].Should().Be(duckDBParameterFloat);
 
@@ -133,13 +133,13 @@ public class ParameterCollectionTests : DuckDBTestBase
         using var defer = new Defer(() => Connection.Execute("DROP TABLE ParametersTestKeyValue;"));
 
         Command.CommandText = "CREATE TABLE ParametersTestKeyValue (KEY INTEGER, VALUE TEXT)";
-		Command.ExecuteNonQuery();
-		Command.CommandText = "INSERT INTO ParametersTestKeyValue (KEY, VALUE) VALUES (42, 'test string');";
-		Command.ExecuteNonQuery();
+        Command.ExecuteNonQuery();
+        Command.CommandText = "INSERT INTO ParametersTestKeyValue (KEY, VALUE) VALUES (42, 'test string');";
+        Command.ExecuteNonQuery();
 
-		Command.CommandText = queryStatement;
-		Command.Parameters.Add(new DuckDBParameter("1", 42));
-		Command.Parameters.Add(new DuckDBParameter("2", "hello"));
+        Command.CommandText = queryStatement;
+        Command.Parameters.Add(new DuckDBParameter("1", 42));
+        Command.Parameters.Add(new DuckDBParameter("2", "hello"));
         var affectedRows = Command.ExecuteNonQuery();
         affectedRows.Should().NotBe(0);
     }
@@ -151,14 +151,14 @@ public class ParameterCollectionTests : DuckDBTestBase
     {
         using var defer = new Defer(() => Connection.Execute("DROP TABLE ParametersTestKeyValue;"));
 
-		Command.CommandText = "CREATE TABLE ParametersTestKeyValue (KEY INTEGER, VALUE TEXT)";
-		Command.ExecuteNonQuery();
-		Command.CommandText = "INSERT INTO ParametersTestKeyValue (KEY, VALUE) VALUES (42, 'test string');";
-		Command.ExecuteNonQuery();
+        Command.CommandText = "CREATE TABLE ParametersTestKeyValue (KEY INTEGER, VALUE TEXT)";
+        Command.ExecuteNonQuery();
+        Command.CommandText = "INSERT INTO ParametersTestKeyValue (KEY, VALUE) VALUES (42, 'test string');";
+        Command.ExecuteNonQuery();
 
-		Command.CommandText = queryStatement;
-		Command.Parameters.Add(new DuckDBParameter("key", 42));
-		Command.Parameters.Add(new DuckDBParameter("value", "hello"));
+        Command.CommandText = queryStatement;
+        Command.Parameters.Add(new DuckDBParameter("key", 42));
+        Command.Parameters.Add(new DuckDBParameter("value", "hello"));
         var affectedRows = Command.ExecuteNonQuery();
         affectedRows.Should().NotBe(0);
     }
@@ -172,7 +172,7 @@ public class ParameterCollectionTests : DuckDBTestBase
     {
         using var defer = new Defer(() => Connection.Execute("DROP TABLE ParametersTestInvalidOrderKeyValue;"));
 
-		Command.CommandText = "CREATE TABLE ParametersTestInvalidOrderKeyValue (KEY INTEGER, VALUE TEXT)";
+        Command.CommandText = "CREATE TABLE ParametersTestInvalidOrderKeyValue (KEY INTEGER, VALUE TEXT)";
         Command.ExecuteNonQuery();
         Command.CommandText = "INSERT INTO ParametersTestInvalidOrderKeyValue (KEY, VALUE) VALUES (42, 'test string');";
         Command.ExecuteNonQuery();
@@ -222,7 +222,7 @@ public class ParameterCollectionTests : DuckDBTestBase
         var dp = new DynamicParameters();
         dp.Add("foo", 1);
         dp.Add("bar", "test");
-        
+
         Connection.Execute(queryStatement, dp).Should().BeGreaterOrEqualTo(1);
         Connection.Execute(queryStatement, new { foo = 1, bar = "test" }).Should().BeGreaterOrEqualTo(1, "Passing parameters as object should work");
     }
@@ -245,7 +245,7 @@ public class ParameterCollectionTests : DuckDBTestBase
 
         Connection.Execute(queryStatement, dp).Should().BeLessOrEqualTo(1);
     }
-    
+
     [Theory]
     [InlineData("SELECT ?1;")]
     [InlineData("SELECT ?;")]
@@ -274,31 +274,31 @@ public class ParameterCollectionTests : DuckDBTestBase
             .Should().ThrowExactly<InvalidOperationException>();
     }
 
-	[Fact]
-	public void BindUnreferencedNamedParameterInParameterlessQueryTest()
-	{
-		Command.CommandText = "SELECT 42";
-		Command.Parameters.Add(new DuckDBParameter("unused", 24));
-		var scalar = Command.ExecuteScalar();
-		scalar.Should().Be(42);
-	}
+    [Fact]
+    public void BindUnreferencedNamedParameterInParameterlessQueryTest()
+    {
+        Command.CommandText = "SELECT 42";
+        Command.Parameters.Add(new DuckDBParameter("unused", 24));
+        var scalar = Command.ExecuteScalar();
+        scalar.Should().Be(42);
+    }
 
 
-	[Fact]
+    [Fact]
     public void BindUnreferencedNamedParameterTest()
     {
-		Command.CommandText = "SELECT $used";
-		Command.Parameters.Add(new DuckDBParameter("unused", 24));
-		Command.Parameters.Add(new DuckDBParameter("used", 42));
-		var scalar = Command.ExecuteScalar();
+        Command.CommandText = "SELECT $used";
+        Command.Parameters.Add(new DuckDBParameter("unused", 24));
+        Command.Parameters.Add(new DuckDBParameter("used", 42));
+        var scalar = Command.ExecuteScalar();
         scalar.Should().Be(42);
     }
 
     [Fact]
     public void BindUnreferencedPositionalParameterTest()
     {
-		Command.CommandText = "SELECT 1";
-		Command.Parameters.Add(new DuckDBParameter(42));    // unused
+        Command.CommandText = "SELECT 1";
+        Command.Parameters.Add(new DuckDBParameter(42));    // unused
         var scalar = Command.ExecuteScalar();
         scalar.Should().Be(1);
     }


### PR DESCRIPTION
Ignore unused parameters instead of throwing an `InvalidOperationException`.

Closes #158 

Unchanged behavior: 
1. If there are less parameters than expected, then `InvalidOperationException: Invalid number of parameters` is thrown. Covered by existing `MissingParametersThrowsException` test.
2. If there are unbound parameters, then `DuckDB.NET.Data.DuckDBException : Invalid Input Error: Values were not provided for the following prepared statement parameters:` is thrown by duckdb.

