### PR TITLE
Implement Connection.GetSchema

### DIFF
--- a/DuckDB.NET.Data/DuckDBConnection.cs
+++ b/DuckDB.NET.Data/DuckDBConnection.cs
@@ -210,4 +210,13 @@ public class DuckDBConnection : DbConnection
 
         return duplicatedConnection;
     }
+
+    public override DataTable GetSchema() =>
+        GetSchema("MetaDataCollections");
+
+    public override DataTable GetSchema(string collectionName) =>
+        GetSchema(collectionName, null);
+
+    public override DataTable GetSchema(string collectionName, string?[]? restrictionValues) =>
+        DuckDBSchema.GetSchema(this, collectionName, restrictionValues);
 }

--- a/DuckDB.NET.Data/DuckDBConnection.cs
+++ b/DuckDB.NET.Data/DuckDBConnection.cs
@@ -212,7 +212,7 @@ public class DuckDBConnection : DbConnection
     }
 
     public override DataTable GetSchema() =>
-        GetSchema("MetaDataCollections");
+        GetSchema(DbMetaDataCollectionNames.MetaDataCollections);
 
     public override DataTable GetSchema(string collectionName) =>
         GetSchema(collectionName, null);

--- a/DuckDB.NET.Data/DuckDBSchema.cs
+++ b/DuckDB.NET.Data/DuckDBSchema.cs
@@ -8,9 +8,8 @@ namespace DuckDB.NET.Data;
 
 internal static class DuckDBSchema
 {
-    public static DataTable GetSchema(DuckDBConnection connection, string collectionName, string?[]? restrictionValues)
-    {
-        return collectionName.ToUpperInvariant() switch
+    public static DataTable GetSchema(DuckDBConnection connection, string collectionName, string?[]? restrictionValues) =>
+        collectionName.ToUpperInvariant() switch
         {
             "METADATACOLLECTIONS" => GetMetaDataCollections(),
             "RESTRICTIONS" => GetRestrictions(),
@@ -19,7 +18,6 @@ internal static class DuckDBSchema
             "COLUMNS" => GetColumns(connection, restrictionValues),
             _ => throw new ArgumentOutOfRangeException(nameof(collectionName), collectionName, "Invalid collection name.")
         };
-    }
 
     private static DataTable GetMetaDataCollections() =>
         new(DbMetaDataCollectionNames.MetaDataCollections)
@@ -35,7 +33,8 @@ internal static class DuckDBSchema
                 { DbMetaDataCollectionNames.MetaDataCollections, 0, 0 },
                 { DbMetaDataCollectionNames.Restrictions, 0, 0 },
                 { DbMetaDataCollectionNames.ReservedWords, 0, 0 },
-                { "Tables", 4, 3 }
+                { "Tables", 4, 3 },
+                { "Columns", 4, 4 }
             }
         };
 
@@ -54,7 +53,12 @@ internal static class DuckDBSchema
                 { "Tables", "Catalog", "table_catalog", 1 },
                 { "Tables", "Schema", "table_schema", 2 },
                 { "Tables", "Table", "table_name", 3 },
-                { "Tables", "TableType", "table_type", 4 }
+                { "Tables", "TableType", "table_type", 4 },
+
+                { "Columns", "Catalog", "table_catalog", 1 },
+                { "Columns", "Schema", "table_schema", 2 },
+                { "Columns", "Table", "table_name", 3 },
+                { "Columns", "Column", "column_name", 4 }
             }
         };
 

--- a/DuckDB.NET.Data/DuckDBSchema.cs
+++ b/DuckDB.NET.Data/DuckDBSchema.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Data;
+using System.Data.Common;
 using System.Linq;
 using System.Text;
 
@@ -20,25 +21,25 @@ internal static class DuckDBSchema
     }
 
     private static DataTable GetMetaDataCollections() =>
-        new("MetaDataCollections")
+        new(DbMetaDataCollectionNames.MetaDataCollections)
         {
             Columns =
             {
-                { "CollectionName", typeof(string) },
-                { "NumberOfRestrictions", typeof(int) },
-                { "NumberOfIdentifierParts", typeof(int) }
+                { DbMetaDataColumnNames.CollectionName, typeof(string) },
+                { DbMetaDataColumnNames.NumberOfRestrictions, typeof(int) },
+                { DbMetaDataColumnNames.NumberOfIdentifierParts, typeof(int) }
             },
             Rows =
             {
-                { "MetaDataCollections", 0, 0 },
-                { "Restrictions", 0, 0 },
-                { "ReservedWords", 0, 0 },
+                { DbMetaDataCollectionNames.MetaDataCollections, 0, 0 },
+                { DbMetaDataCollectionNames.Restrictions, 0, 0 },
+                { DbMetaDataCollectionNames.ReservedWords, 0, 0 },
                 { "Tables", 4, 3 }
             }
         };
 
     private static DataTable GetRestrictions() =>
-        new("Restrictions")
+        new(DbMetaDataCollectionNames.Restrictions)
         {
             Columns =
             {
@@ -58,9 +59,9 @@ internal static class DuckDBSchema
 
     private static DataTable GetReservedWords(DuckDBConnection connection)
     {
-        var table = new DataTable("ReservedWords")
+        var table = new DataTable(DbMetaDataCollectionNames.ReservedWords)
         {
-            Columns = { { "ReservedWord", typeof(string) } }
+            Columns = { { DbMetaDataColumnNames.ReservedWord, typeof(string) } }
         };
 
         using var command = connection.CreateCommand();

--- a/DuckDB.NET.Data/DuckDBSchema.cs
+++ b/DuckDB.NET.Data/DuckDBSchema.cs
@@ -1,0 +1,117 @@
+using System;
+using System.Data;
+using System.Linq;
+using System.Text;
+
+namespace DuckDB.NET.Data;
+
+internal static class DuckDBSchema
+{
+    public static DataTable GetSchema(DuckDBConnection connection, string collectionName, string?[]? restrictionValues)
+    {
+        return collectionName.ToUpperInvariant() switch
+        {
+            "METADATACOLLECTIONS" => GetMetaDataCollections(),
+            "RESTRICTIONS" => GetRestrictions(),
+            "TABLES" => GetTables(connection, restrictionValues),
+            _ => throw new ArgumentOutOfRangeException(nameof(collectionName), collectionName, "Invalid collection name.")
+        };
+    }
+
+    private static DataTable GetMetaDataCollections() =>
+        new("MetaDataCollections")
+        {
+            Columns =
+            {
+                { "CollectionName", typeof(string) },
+                { "NumberOfRestrictions", typeof(int) },
+                { "NumberOfIdentifierParts", typeof(int) }
+            },
+            Rows =
+            {
+                { "MetaDataCollections", 0, 0 },
+                { "Restrictions", 0, 0 },
+                { "Tables", 4, 3 }
+            }
+        };
+
+    private static DataTable GetRestrictions() =>
+        new("Restrictions")
+        {
+            Columns =
+            {
+                { "CollectionName", typeof(string) },
+                { "RestrictionName", typeof(string) },
+                { "RestrictionDefault", typeof(string) },
+                { "RestrictionNumber", typeof(int) }
+            },
+            Rows =
+            {
+                { "Tables", "Catalog", "table_catalog", 1 },
+                { "Tables", "Schema", "table_schema", 2 },
+                { "Tables", "Table", "table_name", 3 },
+                { "Tables", "TableType", "table_type", 4 }
+            }
+        };
+
+    private static DataTable GetTables(DuckDBConnection connection, string?[]? restrictionValues)
+    {
+        var table = new DataTable("Tables")
+        {
+            Columns =
+            {
+                "table_catalog",
+                "table_schema",
+                "table_name",
+                "table_type"
+            }
+        };
+
+        const string query = "SELECT table_catalog, table_schema, table_name, table_type FROM information_schema.tables";
+
+        var command = BuildCommand(connection, query, restrictionValues, true,
+            "table_catalog", "table_schema", "table_name", "table_type");
+        var reader = command.ExecuteReader();
+        while (reader.Read())
+        {
+            var values = new object[reader.FieldCount];
+            reader.GetValues(values);
+            table.Rows.Add(values);
+        }
+
+        return table;
+    }
+
+    private static DuckDBCommand BuildCommand(DuckDBConnection connection, string query, string?[]? restrictions, bool addWhere, params string[]? names)
+    {
+        var command = connection.CreateCommand();
+        if (restrictions == null || names == null)
+        {
+            command.CommandText = query;
+            return command;
+        }
+
+        var builder = new StringBuilder(query);
+        foreach (var (name, restriction) in names.Zip(restrictions, Tuple.Create))
+        {
+            if (restriction?.Length > 0)
+            {
+                if (addWhere)
+                {
+                    builder.Append(" WHERE ");
+                    addWhere = false;
+                }
+                else
+                {
+                    builder.Append(" AND ");
+                }
+
+                builder.Append($"{name} = ${name}");
+                command.Parameters.Add(new DuckDBParameter(name, restriction));
+            }
+        }
+
+        command.CommandText = builder.ToString();
+        return command;
+    }
+}

--- a/DuckDB.NET.Data/DuckDBSchema.cs
+++ b/DuckDB.NET.Data/DuckDBSchema.cs
@@ -32,6 +32,7 @@ internal static class DuckDBSchema
             {
                 { "MetaDataCollections", 0, 0 },
                 { "Restrictions", 0, 0 },
+                { "ReservedWords", 0, 0 },
                 { "Tables", 4, 3 }
             }
         };

--- a/DuckDB.NET.Data/DuckDBSchema.cs
+++ b/DuckDB.NET.Data/DuckDBSchema.cs
@@ -73,10 +73,7 @@ internal static class DuckDBSchema
 
     private static DataTable GetTables(DuckDBConnection connection, string?[]? restrictionValues)
     {
-        var table = new DataTable("Tables")
-        {
-            Columns = { "table_catalog", "table_schema", "table_name", "table_type" }
-        };
+        var table = new DataTable("Tables");
 
         const string query = "SELECT table_catalog, table_schema, table_name, table_type FROM information_schema.tables";
 

--- a/DuckDB.NET.Data/DuckDbMetaDataCollectionNames.cs
+++ b/DuckDB.NET.Data/DuckDbMetaDataCollectionNames.cs
@@ -1,0 +1,9 @@
+namespace DuckDB.NET.Data;
+
+internal static class DuckDbMetaDataCollectionNames
+{
+    public const string Tables = "Tables";
+    public const string Columns = "Columns";
+    public const string ForeignKeys = "ForeignKeys";
+    public const string Indexes = "Indexes";
+}

--- a/DuckDB.NET.Test/Parameters/SchemaTests.cs
+++ b/DuckDB.NET.Test/Parameters/SchemaTests.cs
@@ -66,6 +66,14 @@ public class SchemaTests(DuckDBDatabaseFixture db) : DuckDBTestBase(db)
     }
 
     [Fact]
+    public void ReservedWords()
+    {
+        var schema = Connection.GetSchema(DbMetaDataCollectionNames.ReservedWords);
+        Assert.NotEmpty(schema.Rows);
+        Assert.Contains("select", schema.Rows.Cast<DataRow>().Select(c => c["ReservedWord"]));
+    }
+
+    [Fact]
     public void Tables()
     {
         Command.CommandText = "CREATE TABLE bar(key INTEGER)";

--- a/DuckDB.NET.Test/Parameters/SchemaTests.cs
+++ b/DuckDB.NET.Test/Parameters/SchemaTests.cs
@@ -76,20 +76,20 @@ public class SchemaTests(DuckDBDatabaseFixture db) : DuckDBTestBase(db)
     [Fact]
     public void Tables()
     {
-        Command.CommandText = "CREATE TABLE bar(key INTEGER)";
+        Command.CommandText = "CREATE TABLE foo(key INTEGER)";
         Command.ExecuteNonQuery();
 
         var schema = Connection.GetSchema("Tables");
         Assert.Equal(1, schema.Rows.Count);
-        Assert.Equal("bar", schema.Rows[0]["table_name"]);
+        Assert.Equal("foo", schema.Rows[0]["table_name"]);
     }
     
     [Fact]
     public void TablesWithRestrictions()
     {
-        Command.CommandText = "CREATE TABLE foo(key INTEGER)";
-        Command.ExecuteNonQuery();
         Command.CommandText = "CREATE TABLE bar(key INTEGER)";
+        Command.ExecuteNonQuery();
+        Command.CommandText = "CREATE TABLE baz(key INTEGER)";
         Command.ExecuteNonQuery();
 
         var schema = Connection.GetSchema("Tables", [null, null, "bar"]);

--- a/DuckDB.NET.Test/Parameters/SchemaTests.cs
+++ b/DuckDB.NET.Test/Parameters/SchemaTests.cs
@@ -1,0 +1,91 @@
+using System.Data;
+using System.Data.Common;
+using System.Linq;
+using Xunit;
+
+namespace DuckDB.NET.Test.Parameters;
+
+public class SchemaTests(DuckDBDatabaseFixture db) : DuckDBTestBase(db)
+{
+    [Fact]
+    public void MetaDataCollections()
+    {
+        var schema = Connection.GetSchema(DbMetaDataCollectionNames.MetaDataCollections);
+        Assert.NotEmpty(schema.Rows);
+
+        foreach (DataRow row in schema.Rows)
+        {
+            var collectionName = (string)row!["CollectionName"];
+            Assert.NotNull(Connection.GetSchema(collectionName));
+        }
+    }
+    
+    [Fact]
+    public void NoParametersShouldBeEquivalentToMetaDataCollections()
+    {
+        var actualSchema = Connection.GetSchema();
+        var actual = actualSchema.Rows
+            .Cast<DataRow>()
+            .Select(r => (string)r["CollectionName"])
+            .ToList();
+
+        var expectedSchema = Connection.GetSchema(DbMetaDataCollectionNames.MetaDataCollections);
+        var expected = expectedSchema.Rows
+            .Cast<DataRow>()
+            .Select(r => (string)r["CollectionName"])
+            .ToList();
+
+        Assert.Equal(expected, actual);
+    }
+
+    [Fact]
+    public void Restrictions()
+    {
+        var restrictions = Connection.GetSchema(DbMetaDataCollectionNames.Restrictions);
+        Assert.NotEmpty(restrictions.Rows);
+        
+        var collections = Connection.GetSchema(DbMetaDataCollectionNames.MetaDataCollections);
+        var restrictionsByCollectionName = restrictions.Rows.Cast<DataRow>()
+            .GroupBy(r => r["CollectionName"])
+            .ToDictionary(g => g.Key, g => g.Count());
+        
+        foreach (DataRow row in collections.Rows)
+        {
+            var collectionName = (string)row["CollectionName"];
+            var numberOfRestrictions = (int)row["NumberOfRestrictions"];
+
+            if (numberOfRestrictions != 0)
+            {
+                Assert.Equal(numberOfRestrictions, restrictionsByCollectionName[collectionName]);
+            }
+            else
+            {
+                Assert.DoesNotContain(collectionName, restrictionsByCollectionName.Keys);
+            }
+        }
+    }
+
+    [Fact]
+    public void Tables()
+    {
+        Command.CommandText = "CREATE TABLE bar(key INTEGER)";
+        Command.ExecuteNonQuery();
+
+        var schema = Connection.GetSchema("Tables");
+        Assert.Equal(1, schema.Rows.Count);
+        Assert.Equal("bar", schema.Rows[0]["table_name"]);
+    }
+    
+    [Fact]
+    public void TablesWithRestrictions()
+    {
+        Command.CommandText = "CREATE TABLE foo(key INTEGER)";
+        Command.ExecuteNonQuery();
+        Command.CommandText = "CREATE TABLE bar(key INTEGER)";
+        Command.ExecuteNonQuery();
+
+        var schema = Connection.GetSchema("Tables", [null, null, "bar"]);
+        Assert.Equal(1, schema.Rows.Count);
+        Assert.Equal("bar", schema.Rows[0]["table_name"]);
+    }
+}

--- a/DuckDB.NET.Test/Parameters/SchemaTests.cs
+++ b/DuckDB.NET.Test/Parameters/SchemaTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Data;
 using System.Data.Common;
 using System.Linq;
@@ -7,6 +8,12 @@ namespace DuckDB.NET.Test.Parameters;
 
 public class SchemaTests(DuckDBDatabaseFixture db) : DuckDBTestBase(db)
 {
+    [Fact]
+    public void InvalidCollection()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => Connection.GetSchema("Invalid"));
+    }
+    
     [Fact]
     public void MetaDataCollections()
     {

--- a/DuckDB.NET.Test/SchemaTests.cs
+++ b/DuckDB.NET.Test/SchemaTests.cs
@@ -108,7 +108,13 @@ public class SchemaTests : DuckDBTestBase
         Assert.Equal(1, schema.Rows.Count);
         Assert.Equal("bar", schema.Rows[0]["table_name"]);
     }
-   
+ 
+    [Fact]
+    public void TablesTooManyRestrictions()
+    {
+        Assert.Throws<ArgumentException>(() => Connection.GetSchema("Tables", new string [5]));
+    }
+  
     [Fact]
     public void ColumnsWithRestrictions()
     {
@@ -117,13 +123,25 @@ public class SchemaTests : DuckDBTestBase
         Assert.Equal("foo", schema.Rows[0]["table_name"]);
         Assert.Equal("foo_id", schema.Rows[0]["column_name"]);
     }
-   
+
+    [Fact]
+    public void ColumnsTooManyRestrictions()
+    {
+        Assert.Throws<ArgumentException>(() => Connection.GetSchema("Columns", new string [5]));
+    }
+
     [Fact]
     public void ForeignKeysWithRestrictions()
     {
         var schema = Connection.GetSchema("ForeignKeys", [null, null, "bar", null]);
         Assert.Equal(1, schema.Rows.Count);
         Assert.Equal("bar", schema.Rows[0]["table_name"]);
+    }
+
+    [Fact]
+    public void ForeignKeysTooManyRestrictions()
+    {
+        Assert.Throws<ArgumentException>(() => Connection.GetSchema("ForeignKeys", new string [5]));
     }
 
     [Fact]
@@ -150,6 +168,12 @@ public class SchemaTests : DuckDBTestBase
         Assert.Equal("foo_name_uq", schema.Rows[0]["index_name"]);
         Assert.Equal(true, schema.Rows[0]["is_unique"]);
         Assert.Equal(false, schema.Rows[0]["is_primary"]);
+    }
+
+    [Fact]
+    public void IndexesTooManyRestrictions()
+    {
+        Assert.Throws<ArgumentException>(() => Connection.GetSchema("Indexes", new string [5]));
     }
 
     private static IEnumerable<string> GetValues(DataTable schema, string columnName) =>

--- a/DuckDB.NET.Test/SchemaTests.cs
+++ b/DuckDB.NET.Test/SchemaTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Data;
 using System.Data.Common;
 using System.Linq;
@@ -12,9 +13,11 @@ public class SchemaTests : DuckDBTestBase
     {
         Command.CommandText =
             """
-            CREATE TABLE IF NOT EXISTS foo(foo_id INTEGER PRIMARY KEY);
-            CREATE TABLE IF NOT EXISTS bar(bar_id INTEGER PRIMARY KEY, foo_id INTEGER REFERENCES foo(foo_id));
+            CREATE TABLE IF NOT EXISTS foo(foo_id INTEGER PRIMARY KEY, name VARCHAR(100), date DATE UNIQUE);
+            CREATE TABLE IF NOT EXISTS bar(bar_id INTEGER PRIMARY KEY, name VARCHAR(100), date DATE UNIQUE, foo_id INTEGER REFERENCES foo(foo_id));
             CREATE TABLE IF NOT EXISTS baz(baz_id INTEGER PRIMARY KEY, bar_id INTEGER REFERENCES bar(bar_id));
+            CREATE UNIQUE INDEX foo_name_uq ON foo(name);
+            CREATE INDEX bar_name_ix ON bar(name);
             """;
         Command.ExecuteNonQuery();
     }
@@ -88,7 +91,7 @@ public class SchemaTests : DuckDBTestBase
     {
         var schema = Connection.GetSchema(DbMetaDataCollectionNames.ReservedWords);
         Assert.NotEmpty(schema.Rows);
-        Assert.Contains("select", schema.Rows.Cast<DataRow>().Select(c => c["ReservedWord"]));
+        Assert.Contains("select", GetValues(schema, "ReservedWord"));
     }
 
     [Fact]
@@ -96,10 +99,10 @@ public class SchemaTests : DuckDBTestBase
     {
         var schema = Connection.GetSchema("Tables");
         Assert.Equal(3, schema.Rows.Count);
-        var tableNames = schema.Rows.Cast<DataRow>().Select(x => (string)x["table_name"]);
-        Assert.Equal(tableNames, ["bar", "baz", "foo"]);
+        var tableNames = GetValues(schema, "table_name");
+        Assert.Equal(["bar", "baz", "foo"], tableNames);
     }
-    
+
     [Fact]
     public void TablesWithRestrictions()
     {
@@ -124,4 +127,27 @@ public class SchemaTests : DuckDBTestBase
         Assert.Equal(1, schema.Rows.Count);
         Assert.Equal("bar", schema.Rows[0]["table_name"]);
     }
+    
+    [Fact]
+    public void BarIndexes()
+    {
+        var schema = Connection.GetSchema("Indexes", [null, null, "bar", null]);
+        Assert.Equal(1, schema.Rows.Count);
+        Assert.Equal("bar_name_ix", schema.Rows[0]["index_name"]);
+        Assert.Equal(false, schema.Rows[0]["is_unique"]);
+        Assert.Equal(false, schema.Rows[0]["is_primary"]);
+    }
+    
+    [Fact]
+    public void FooIndexes()
+    {
+        var schema = Connection.GetSchema("Indexes", [null, null, "foo", null]);
+        Assert.Equal(1, schema.Rows.Count);
+        Assert.Equal("foo_name_uq", schema.Rows[0]["index_name"]);
+        Assert.Equal(true, schema.Rows[0]["is_unique"]);
+        Assert.Equal(false, schema.Rows[0]["is_primary"]);
+    }
+
+    private static IEnumerable<string> GetValues(DataTable schema, string columnName) =>
+        schema.Rows.Cast<DataRow>().Select(r => (string)r[columnName]);
 }

--- a/DuckDB.NET.Test/SchemaTests.cs
+++ b/DuckDB.NET.Test/SchemaTests.cs
@@ -12,9 +12,9 @@ public class SchemaTests : DuckDBTestBase
     {
         Command.CommandText =
             """
-            CREATE TABLE IF NOT EXISTS foo(foo_id INTEGER);
-            CREATE TABLE IF NOT EXISTS bar(bar_id INTEGER);
-            CREATE TABLE IF NOT EXISTS baz(baz_id INTEGER);
+            CREATE TABLE IF NOT EXISTS foo(foo_id INTEGER PRIMARY KEY);
+            CREATE TABLE IF NOT EXISTS bar(bar_id INTEGER PRIMARY KEY, foo_id INTEGER REFERENCES foo(foo_id));
+            CREATE TABLE IF NOT EXISTS baz(baz_id INTEGER PRIMARY KEY, bar_id INTEGER REFERENCES bar(bar_id));
             """;
         Command.ExecuteNonQuery();
     }
@@ -115,5 +115,13 @@ public class SchemaTests : DuckDBTestBase
         Assert.Equal(1, schema.Rows.Count);
         Assert.Equal("foo", schema.Rows[0]["table_name"]);
         Assert.Equal("foo_id", schema.Rows[0]["column_name"]);
+    }
+   
+    [Fact]
+    public void ForeignKeysWithRestrictions()
+    {
+        var schema = Connection.GetSchema("ForeignKeys", [null, null, "bar", null]);
+        Assert.Equal(1, schema.Rows.Count);
+        Assert.Equal("bar", schema.Rows[0]["table_name"]);
     }
 }

--- a/DuckDB.NET.Test/SchemaTests.cs
+++ b/DuckDB.NET.Test/SchemaTests.cs
@@ -16,8 +16,6 @@ public class SchemaTests : DuckDBTestBase
             CREATE TABLE IF NOT EXISTS foo(foo_id INTEGER PRIMARY KEY, name VARCHAR(100), date DATE UNIQUE);
             CREATE TABLE IF NOT EXISTS bar(bar_id INTEGER PRIMARY KEY, name VARCHAR(100), date DATE UNIQUE, foo_id INTEGER REFERENCES foo(foo_id));
             CREATE TABLE IF NOT EXISTS baz(baz_id INTEGER PRIMARY KEY, bar_id INTEGER REFERENCES bar(bar_id));
-            CREATE UNIQUE INDEX foo_name_uq ON foo(name);
-            CREATE INDEX bar_name_ix ON bar(name);
             """;
         Command.ExecuteNonQuery();
     }
@@ -127,20 +125,26 @@ public class SchemaTests : DuckDBTestBase
         Assert.Equal(1, schema.Rows.Count);
         Assert.Equal("bar", schema.Rows[0]["table_name"]);
     }
-    
+
     [Fact]
-    public void BarIndexes()
+    public void NonUniqueIndex()
     {
+        Command.CommandText = "CREATE INDEX bar_name_ix ON bar(name);";
+        Command.ExecuteNonQuery();
+
         var schema = Connection.GetSchema("Indexes", [null, null, "bar", null]);
         Assert.Equal(1, schema.Rows.Count);
         Assert.Equal("bar_name_ix", schema.Rows[0]["index_name"]);
         Assert.Equal(false, schema.Rows[0]["is_unique"]);
         Assert.Equal(false, schema.Rows[0]["is_primary"]);
     }
-    
+
     [Fact]
-    public void FooIndexes()
+    public void UniqueIndex()
     {
+        Command.CommandText = "CREATE UNIQUE INDEX foo_name_uq ON foo(name);";
+        Command.ExecuteNonQuery();
+
         var schema = Connection.GetSchema("Indexes", [null, null, "foo", null]);
         Assert.Equal(1, schema.Rows.Count);
         Assert.Equal("foo_name_uq", schema.Rows[0]["index_name"]);


### PR DESCRIPTION
This PR implements `Connection.GetSchema`.

Standard collections:
✔️ MetaDataCollections
✔️ Restrictions
✔️ ReservedWords
❌ DataSourceInformation
❌ DataTypes

Non standard common collections
✔️ Tables
✔️ Columns
✔️ ForeignKeys
✔️ Indexes