### PR TITLE
Make the prepared statement after the check succeed

### DIFF
--- a/DuckDB.NET.Data/Internal/PreparedStatement.cs
+++ b/DuckDB.NET.Data/Internal/PreparedStatement.cs
@@ -59,9 +59,9 @@ internal sealed class PreparedStatement : IDisposable
             {
                 var status = NativeMethods.ExtractStatements.DuckDBPrepareExtractedStatement(connection, extractedStatements, index, out var statement);
 
-                using var preparedStatement = new PreparedStatement(statement);
                 if (status.IsSuccess())
                 {
+                    using var preparedStatement = new PreparedStatement(statement);
                     using var result = preparedStatement.Execute(parameters, useStreamingMode);
                     yield return result;
                 }


### PR DESCRIPTION
If no succeed, Is the `PreparedStatement `  unnecessary. 