### PR TITLE
Support AOT read, add AOT test console

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <PropertyGroup Label="Common assembly attributes">
-    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net6.0;net8.0</TargetFrameworks>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
     <LangVersion>default</LangVersion>
 
@@ -36,6 +36,10 @@
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
 
+  </PropertyGroup>
+  
+  <PropertyGroup Condition="'$(PublishAot)'!=''">
+    <TargetFrameworks>net8.0</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/DuckDB.NET.AOT/AOT.csproj
+++ b/DuckDB.NET.AOT/AOT.csproj
@@ -1,0 +1,41 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFrameworks>net8.0</TargetFrameworks>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <PublishAot>true</PublishAot>
+    <InvariantGlobalization>true</InvariantGlobalization>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\DuckDB.NET.Bindings\Bindings.csproj" />
+    <ProjectReference Include="..\DuckDB.NET.Data\Data.csproj" />
+  </ItemGroup>
+
+	<Target Name="CallExecutable" BeforeTargets="GenerateAdditionalSources">
+		<MSBuild Projects="..\DuckDB.NET.Bindings\Bindings.csproj" Targets="DownloadNativeLibs" Properties="BuildType=Full;" />
+	</Target>
+	<ItemGroup>
+		<None Condition="'$(RuntimeIdentifier)'=='win-x64'" Include="..\DuckDB.NET.Bindings\obj\runtimes\**\*.dll">
+			<Visible>false</Visible>
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+			<PackagePath>\</PackagePath>
+			<Link>%(FileName)%(Extension)</Link>
+		</None>
+		<None Condition="'$(RuntimeIdentifier)'=='linux-x64'" Include="..\DuckDB.NET.Bindings\obj\runtimes\**\*.so">
+			<Visible>false</Visible>
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+			<PackagePath>\</PackagePath>
+			<Link>%(FileName)%(Extension)</Link>
+		</None>
+		<None Condition="'$(RuntimeIdentifier)'=='oxs'" Include="..\DuckDB.NET.Bindings\obj\runtimes\**\*.dylib">
+			<Visible>false</Visible>
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+			<PackagePath>\</PackagePath>
+			<Link>%(FileName)%(Extension)</Link>
+		</None>
+	</ItemGroup>
+
+</Project>

--- a/DuckDB.NET.AOT/Program.cs
+++ b/DuckDB.NET.AOT/Program.cs
@@ -1,0 +1,54 @@
+﻿using DuckDB.NET.Data;
+
+namespace DuckDB.NET.AOT
+{
+    internal class Program
+    {
+        static void Main(string[] args)
+        {
+            using var conn = new DuckDBConnection(DuckDBConnectionStringBuilder.InMemoryConnectionString);
+            conn.Open();
+            using (var comm = conn.CreateCommand())
+            {
+                comm.CommandText = "SELECT 1";
+                comm.ExecuteNonQuery();
+
+                comm.CommandText = "SELECT 1";
+                using (var reader = comm.ExecuteReader())
+                {
+                    while (reader.Read())
+                    {
+                        _ = reader.GetInt32(0);
+                    }
+                }
+
+                comm.CommandText = "SELECT [1,2,3]";
+                using (var reader = comm.ExecuteReader())
+                {
+                    while (reader.Read())
+                    {
+                        Console.Write("[");
+                        foreach (var item in (List<int>)reader[0])
+                        {
+                            Console.Write(item+",");
+                        }
+                        Console.WriteLine("]");
+                    }
+                }
+                comm.CommandText = "select {\"a\":1,\"b\":2};";
+                using (var reader = comm.ExecuteReader())
+                {
+                    while (reader.Read())
+                    {
+                        Console.Write("{");
+                        foreach (var item in (Dictionary<string,object>)reader[0])
+                        {
+                            Console.Write($"{item.Key}={item.Value}, ");
+                        }
+                        Console.WriteLine("}");
+                    }
+                }
+            }
+        }
+    }
+}

--- a/DuckDB.NET.Bindings/Bindings.csproj
+++ b/DuckDB.NET.Bindings/Bindings.csproj
@@ -4,7 +4,7 @@
     <Description>DuckDB Bindings for C#.</Description>
     <PackageReleaseNotes>Update to DuckDB 0.10.3.</PackageReleaseNotes>
     <RootNamespace>DuckDB.NET.Native</RootNamespace>
-    <RuntimeIdentifiers>win-x64;linux-x64;linux-arm64;osx</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win-x64;linux-x64;linux-arm64;osx-x64</RuntimeIdentifiers>
     <DuckDbArtifactRoot Condition=" '$(DuckDbArtifactRoot)' == '' ">https://github.com/duckdb/duckdb/releases/download/v0.10.3</DuckDbArtifactRoot>
     <SignAssembly>True</SignAssembly>
     <AssemblyOriginatorKeyFile>..\keyPair.snk</AssemblyOriginatorKeyFile>
@@ -15,13 +15,13 @@
   <PropertyGroup Condition="'$(BuildType)' == 'ManagedOnly' ">
     <Description>$(Description) $(NoNativeText)</Description>
   </PropertyGroup>
-  
+	
   <!-- Download and include the native libraries into the nuget package-->
   <Target Name="DownloadNativeLibs" BeforeTargets="GenerateAdditionalSources" Condition="'$(BuildType)' == 'Full' ">
     <MSBuild Projects="DownloadNativeLibs.targets" Properties="Rid=win-x64;LibUrl=$(DuckDbArtifactRoot)/libduckdb-windows-amd64.zip" />
     <MSBuild Projects="DownloadNativeLibs.targets" Properties="Rid=linux-x64;LibUrl=$(DuckDbArtifactRoot)/libduckdb-linux-amd64.zip" />
     <MSBuild Condition=" '$(SkipLinuxArm)' == '' " Projects="DownloadNativeLibs.targets" Properties="Rid=linux-arm64;LibUrl=$(DuckDbArtifactRoot)/libduckdb-linux-aarch64.zip" />
-    <MSBuild Projects="DownloadNativeLibs.targets" Properties="Rid=osx;LibUrl=$(DuckDbArtifactRoot)/libduckdb-osx-universal.zip" />
+    <MSBuild Projects="DownloadNativeLibs.targets" Properties="Rid=osx-x64;LibUrl=$(DuckDbArtifactRoot)/libduckdb-osx-universal.zip" />
   </Target>
   <Target Name="CleanNativeLibs" BeforeTargets="Clean" Condition="'$(BuildType)' == 'Full' ">
     <RemoveDir Directories="obj\runtimes" />

--- a/DuckDB.NET.Data/DuckDBException.cs
+++ b/DuckDB.NET.Data/DuckDBException.cs
@@ -1,4 +1,5 @@
-﻿using System.Data.Common;
+﻿using System;
+using System.Data.Common;
 using System.Runtime.Serialization;
 using DuckDB.NET.Native;
 
@@ -10,6 +11,7 @@ public class DuckDBException : DbException
     {
     }
 
+    [Obsolete]
     internal DuckDBException(SerializationInfo info, StreamingContext context) : base(info, context)
     {
     }

--- a/DuckDB.NET.Data/Internal/Reader/CreatorCache.cs
+++ b/DuckDB.NET.Data/Internal/Reader/CreatorCache.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Linq.Expressions;
+
+namespace DuckDB.NET.Data.Internal.Reader;
+
+internal static class CreatorCache
+{
+    private static readonly ConcurrentDictionary<Type, Func<object>> creators=new ConcurrentDictionary<Type, Func<object>>();
+
+    public static Func<object> GetCreator(Type type)
+    {
+        return creators.GetOrAdd(type, static t =>
+        {
+            return Expression.Lambda<Func<object>>(Expression.Convert(Expression.New(t), typeof(object))).Compile();
+        });
+    }
+}

--- a/DuckDB.NET.sln
+++ b/DuckDB.NET.sln
@@ -11,6 +11,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Data", "DuckDB.NET.Data\Dat
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Test", "DuckDB.NET.Test\Test.csproj", "{56C63520-26F9-4230-9AD1-04457E5EBF57}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AOT", "DuckDB.NET.AOT\AOT.csproj", "{29DB9656-5E17-4F49-944C-EDC5FF8F9312}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -33,6 +35,10 @@ Global
 		{56C63520-26F9-4230-9AD1-04457E5EBF57}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{56C63520-26F9-4230-9AD1-04457E5EBF57}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{56C63520-26F9-4230-9AD1-04457E5EBF57}.Release|Any CPU.Build.0 = Release|Any CPU
+		{29DB9656-5E17-4F49-944C-EDC5FF8F9312}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{29DB9656-5E17-4F49-944C-EDC5FF8F9312}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{29DB9656-5E17-4F49-944C-EDC5FF8F9312}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{29DB9656-5E17-4F49-944C-EDC5FF8F9312}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
From [Native AOT](https://learn.microsoft.com/en-us/dotnet/core/deploying/native-aot/?tabs=net7%2Cwindows)

DuckDB.NET challenge for AOT maybe it's just a reflection, I change reflection to use `Expression`.

But the test is non-standard.

- [ ] Use [testing-your-native-aot-dotnet-apps](https://devblogs.microsoft.com/dotnet/testing-your-native-aot-dotnet-apps/) to write native aot test
