### PR TITLE
Fix DuckDb.NET not compiling on shallow clone 

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -64,4 +64,17 @@
       <PackagePath></PackagePath>
     </None>
   </ItemGroup>
+
+  <PropertyGroup Label="CI" Condition="'$(CI)' == ''">
+    <CI>false</CI>
+    <!-- GH, CircleCI, GitLab and BitBucket already use CI -->
+    <CI Condition="'$(TF_BUILD)' == 'true' or
+                   '$(TEAMCITY_VERSION)' != '' or
+                   '$(APPVEYOR)' != '' or
+                   '$(BuildRunner)' == 'MyGet' or
+                   '$(JENKINS_URL)' != '' or
+                   '$(TRAVIS)' == 'true' or
+                   '$(BUDDY)' == 'true' or
+                   '$(CODEBUILD_CI)' == 'true'">true</CI>
+  </PropertyGroup>
 </Project>

--- a/DuckDB.NET.Bindings/Bindings.csproj
+++ b/DuckDB.NET.Bindings/Bindings.csproj
@@ -42,7 +42,7 @@ Updated to DuckDB v1.1.3
       <Link>runtimes\%(RecursiveDir)\%(FileName)%(Extension)</Link>
     </None>
   </ItemGroup>
-  <ItemGroup Condition="'$(BuildType)' == 'Full'">
+  <ItemGroup Condition="'$(CI)' == 'true'">
     <PackageReference Include="GitVersion.MsBuild" Version="5.11.1" PrivateAssets="all" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">

--- a/DuckDB.NET.Bindings/Bindings.csproj
+++ b/DuckDB.NET.Bindings/Bindings.csproj
@@ -21,7 +21,7 @@ Updated to DuckDB v1.1.3
   <PropertyGroup Condition="'$(BuildType)' == 'ManagedOnly' ">
     <Description>$(Description) $(NoNativeText)</Description>
   </PropertyGroup>
-  
+
   <!-- Download and include the native libraries into the NuGet package-->
   <Target Name="DownloadNativeLibs" BeforeTargets="GenerateAdditionalSources" Condition="'$(BuildType)' == 'Full' ">
     <MSBuild Projects="DownloadNativeLibs.targets" Properties="Rid=win-x64;LibUrl=$(DuckDbArtifactRoot)/libduckdb-windows-amd64.zip" />
@@ -42,7 +42,7 @@ Updated to DuckDB v1.1.3
       <Link>runtimes\%(RecursiveDir)\%(FileName)%(Extension)</Link>
     </None>
   </ItemGroup>
-  <ItemGroup>
+  <ItemGroup Condition="'$(BuildType)' == 'Full'">
     <PackageReference Include="GitVersion.MsBuild" Version="5.11.1" PrivateAssets="all" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">

--- a/DuckDB.NET.Data/Data.csproj
+++ b/DuckDB.NET.Data/Data.csproj
@@ -19,7 +19,7 @@ Updated to DuckDB v1.1.3
     <Description>$(Description) $(NoNativeText)</Description>
   </PropertyGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition="'$(BuildType)' == 'Full'">
     <PackageReference Include="GitVersion.MsBuild" Version="5.11.1" PrivateAssets="all" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">

--- a/DuckDB.NET.Data/Data.csproj
+++ b/DuckDB.NET.Data/Data.csproj
@@ -19,7 +19,7 @@ Updated to DuckDB v1.1.3
     <Description>$(Description) $(NoNativeText)</Description>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(BuildType)' == 'Full'">
+  <ItemGroup Condition="'$(CI)' == 'true'">
     <PackageReference Include="GitVersion.MsBuild" Version="5.11.1" PrivateAssets="all" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">


### PR DESCRIPTION
## Issue

can't compile repo when doing a shallow clone (`git clone --depth 1`) because of the reference to `GitVersion.MsBuild`

## solution

this is of like a temporary solution, but the reference is not needed for the project to function so it can be disabled for development.

errors:

<details>

when running `dotnet run` and `dotnet build`:

```
/home/melty/.nuget/packages/gitversion.msbuild/5.11.1/tools/GitVersion.MsBuild.targets(9,9): error MSB3073: The command "dotnet --roll-forward Major "/home/melty/.nuget/packages/gitversion.msbuild/5.11.1/tools/netcoreapp3.1/gitversion.dll" "/home/melty/Documents/DuckDB.NET/DuckDB.NET.Bindings"  -output file -outputfile obj/gitversion.json" exited with code 1. [/home/melty/Documents/DuckDB.NET/DuckDB.NET.Bindings/Bindings.csproj::TargetFramework=net8.0]
```

</details>