### PR TITLE
Add overload to register parameterless scalar function

### DIFF
--- a/DuckDB.NET.Data/DuckDBConnection.ScalarFunction.cs
+++ b/DuckDB.NET.Data/DuckDBConnection.ScalarFunction.cs
@@ -15,10 +15,20 @@ partial class DuckDBConnection
 {
 #if NET8_0_OR_GREATER
     [Experimental("DuckDBNET001")]
+    public void RegisterScalarFunction<TResult>(string name, Action<IDuckDBDataWriter, ulong> action, bool isPureFunction = false)
+    {
+        RegisterScalarMethod(name, (_, w, index) => action(w, index), TypeExtensions.GetLogicalType<TResult>(), varargs: false, !isPureFunction);
+    }
+
+    [Obsolete("Prefer using RegisterScalarFunction<TResult>(string name, Action<IDuckDBDataWriter, ulong> action, bool isPureFunction = false)")]
+    [Experimental("DuckDBNET001")]
+#pragma warning disable DuckDBNET001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
     public void RegisterScalarFunction<TResult>(string name, Action<IReadOnlyList<IDuckDBDataReader>, IDuckDBDataWriter, ulong> action, bool isPureFunction = false)
     {
+
         RegisterScalarMethod(name, action, TypeExtensions.GetLogicalType<TResult>(), varargs: false, !isPureFunction);
     }
+#pragma warning restore DuckDBNET001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
 
     [Experimental("DuckDBNET001")]
     public void RegisterScalarFunction<T, TResult>(string name, Action<IReadOnlyList<IDuckDBDataReader>, IDuckDBDataWriter, ulong> action, bool isPureFunction = true, bool @params = false)

--- a/DuckDB.NET.Data/DuckDBConnection.ScalarFunction.cs
+++ b/DuckDB.NET.Data/DuckDBConnection.ScalarFunction.cs
@@ -20,16 +20,6 @@ partial class DuckDBConnection
         RegisterScalarMethod(name, (_, w, index) => action(w, index), TypeExtensions.GetLogicalType<TResult>(), varargs: false, !isPureFunction);
     }
 
-    [Obsolete("Prefer using RegisterScalarFunction<TResult>(string name, Action<IDuckDBDataWriter, ulong> action, bool isPureFunction = false)")]
-    [Experimental("DuckDBNET001")]
-#pragma warning disable DuckDBNET001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
-    public void RegisterScalarFunction<TResult>(string name, Action<IReadOnlyList<IDuckDBDataReader>, IDuckDBDataWriter, ulong> action, bool isPureFunction = false)
-    {
-
-        RegisterScalarMethod(name, action, TypeExtensions.GetLogicalType<TResult>(), varargs: false, !isPureFunction);
-    }
-#pragma warning restore DuckDBNET001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
-
     [Experimental("DuckDBNET001")]
     public void RegisterScalarFunction<T, TResult>(string name, Action<IReadOnlyList<IDuckDBDataReader>, IDuckDBDataWriter, ulong> action, bool isPureFunction = true, bool @params = false)
     {

--- a/DuckDB.NET.Test/ScalarFunctionTests.cs
+++ b/DuckDB.NET.Test/ScalarFunctionTests.cs
@@ -61,32 +61,6 @@ public class ScalarFunctionTests(DuckDBDatabaseFixture db) : DuckDBTestBase(db)
     }
 
     [Fact]
-#pragma warning disable CA1041 // Provide ObsoleteAttribute message
-    [Obsolete]
-#pragma warning restore CA1041 // Provide ObsoleteAttribute message
-    public void RegisterScalarFunctionWithoutParametersObsolete()
-    {
-        var values = new List<long>();
-        Connection.RegisterScalarFunction<long>("my_random_obsolete", (_, writer, rowCount) =>
-        {
-            for (ulong index = 0; index < rowCount; index++)
-            {
-                var value = Random.Shared.NextInt64();
-
-                writer.WriteValue(value, index);
-
-                values.Add(value);
-            }
-        });
-
-        Command.CommandText = "CREATE TABLE big_table_2 AS SELECT (greatest(random(), 0.1) * 10000)::BIGINT i FROM range(100) t(i);";
-        Command.ExecuteNonQuery();
-
-        var longs = Connection.Query<long>("SELECT my_random_obsolete() FROM big_table_2").ToList();
-        longs.Should().BeEquivalentTo(values);
-    }
-
-    [Fact]
     public void RegisterScalarFunctionWithoutParameters()
     {
         var values = new List<long>();
@@ -102,10 +76,10 @@ public class ScalarFunctionTests(DuckDBDatabaseFixture db) : DuckDBTestBase(db)
             }
         });
 
-        Command.CommandText = "CREATE TABLE big_table_2_1 AS SELECT (greatest(random(), 0.1) * 10000)::BIGINT i FROM range(100) t(i);";
+        Command.CommandText = "CREATE TABLE big_table_2 AS SELECT (greatest(random(), 0.1) * 10000)::BIGINT i FROM range(100) t(i);";
         Command.ExecuteNonQuery();
 
-        var longs = Connection.Query<long>("SELECT my_random() FROM big_table_2_1").ToList();
+        var longs = Connection.Query<long>("SELECT my_random() FROM big_table_2").ToList();
         longs.Should().BeEquivalentTo(values);
     }
 


### PR DESCRIPTION
New overload uses callback without `IReadOnlyList<IDuckDBDataReader>`  which is not used.
This will match parameterless table function registration.
Removed old parameterless scalar function registration method.
~Added `[Obsolete]` attribute to old registration function.~