### PR TITLE
fix culture specific decimal parsing

### DIFF
--- a/DuckDB.NET.Bindings/DuckDBWrapperObjects.cs
+++ b/DuckDB.NET.Bindings/DuckDBWrapperObjects.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.Win32.SafeHandles;
 using System;
+using System.Globalization;
 using System.Runtime.CompilerServices;
 
 namespace DuckDB.NET.Native;
@@ -140,7 +141,8 @@ public class DuckDBValue() : SafeHandleZeroOrMinusOneIsInvalid(true), IDuckDBVal
             DuckDBType.Float => Cast(NativeMethods.Value.DuckDBGetFloat(this)),
             DuckDBType.Double => Cast(NativeMethods.Value.DuckDBGetDouble(this)),
             
-            DuckDBType.Decimal => Cast(decimal.Parse(NativeMethods.Value.DuckDBGetVarchar(this))),
+            DuckDBType.Decimal => Cast(decimal.Parse(NativeMethods.Value.DuckDBGetVarchar(this), NumberStyles.Any, CultureInfo.InvariantCulture)),
+            
             DuckDBType.Uuid => Cast(new Guid(NativeMethods.Value.DuckDBGetVarchar(this))),
             
             DuckDBType.HugeInt => Cast(NativeMethods.Value.DuckDBGetHugeInt(this).ToBigInteger()),


### PR DESCRIPTION
This PR fixes decimal parsing in DuckDBWrapperObjects to use CultureInfo.InvariantCulture for consistency across cultures and adds a test to verify decimal handling in table functions under a comma-decimal culture (ka-GE).



