### PR TITLE
Add estimated cardinality support for table functions

### DIFF
--- a/DuckDB.NET.Bindings/NativeMethods/NativeMethods.TableFunction.cs
+++ b/DuckDB.NET.Bindings/NativeMethods/NativeMethods.TableFunction.cs
@@ -89,6 +89,11 @@ public partial class NativeMethods
         [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
         public static unsafe partial void DuckDBBindSetBindData(IntPtr info, IntPtr bindData, delegate* unmanaged[Cdecl]<IntPtr, void> destroy);
 
+        [SuppressGCTransition]
+        [LibraryImport(DuckDbLibrary, EntryPoint = "duckdb_bind_set_cardinality")]
+        [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+        public static unsafe partial void DuckDBBindSetCardinality(IntPtr info, ulong cardinality, [MarshalAs(UnmanagedType.I1)] bool isExact);
+
         // Maybe [SuppressGCTransition]: strdup error string — one small allocation
         [LibraryImport(DuckDbLibrary, EntryPoint = "duckdb_bind_set_error", StringMarshalling = StringMarshalling.Utf8)]
         [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]

--- a/DuckDB.NET.Data/DuckDBConnection.TableFunction.cs
+++ b/DuckDB.NET.Data/DuckDBConnection.TableFunction.cs
@@ -8,7 +8,9 @@ namespace DuckDB.NET.Data;
 
 public record ColumnInfo(string Name, Type Type);
 
-public record TableFunction(IReadOnlyList<ColumnInfo> Columns, IEnumerable Data, ulong? EstimatedCardinality = null);
+public record CardinalityHint(ulong Value, bool IsExact = false);
+
+public record TableFunction(IReadOnlyList<ColumnInfo> Columns, IEnumerable Data, CardinalityHint? Cardinality = null);
 
 partial class DuckDBConnection
 {
@@ -142,9 +144,9 @@ partial class DuckDBConnection
                 NativeMethods.TableFunction.DuckDBBindAddResultColumn(info, columnInfo.Name, logicalType);
             }
 
-            if (tableFunctionData.EstimatedCardinality.HasValue)
+            if (tableFunctionData.Cardinality is { } cardinality)
             {
-                NativeMethods.TableFunction.DuckDBBindSetCardinality(info, tableFunctionData.EstimatedCardinality.Value, isExact: false);
+                NativeMethods.TableFunction.DuckDBBindSetCardinality(info, cardinality.Value, isExact: cardinality.IsExact);
             }
 
             var connectionId = UdfExceptionStore.GetTableFunctionBindConnectionId(info);

--- a/DuckDB.NET.Data/DuckDBConnection.TableFunction.cs
+++ b/DuckDB.NET.Data/DuckDBConnection.TableFunction.cs
@@ -8,7 +8,7 @@ namespace DuckDB.NET.Data;
 
 public record ColumnInfo(string Name, Type Type);
 
-public record TableFunction(IReadOnlyList<ColumnInfo> Columns, IEnumerable Data);
+public record TableFunction(IReadOnlyList<ColumnInfo> Columns, IEnumerable Data, ulong? EstimatedCardinality = null);
 
 partial class DuckDBConnection
 {
@@ -140,6 +140,11 @@ partial class DuckDBConnection
             {
                 using var logicalType = columnInfo.Type.GetLogicalType();
                 NativeMethods.TableFunction.DuckDBBindAddResultColumn(info, columnInfo.Name, logicalType);
+            }
+
+            if (tableFunctionData.EstimatedCardinality.HasValue)
+            {
+                NativeMethods.TableFunction.DuckDBBindSetCardinality(info, tableFunctionData.EstimatedCardinality.Value, isExact: false);
             }
 
             var connectionId = UdfExceptionStore.GetTableFunctionBindConnectionId(info);

--- a/DuckDB.NET.Test/TableFunctionTests.cs
+++ b/DuckDB.NET.Test/TableFunctionTests.cs
@@ -424,47 +424,51 @@ public class TableFunctionTests(DuckDBDatabaseFixture db) : DuckDBTestBase(db)
         ex.InnerException.Should().BeSameAs(originalException);
     }
 
-    [Fact]
-    public void RegisterTableFunctionWithEstimatedCardinality()
+    [Theory]
+    [InlineData(100, false, "card_estimated")]
+    [InlineData(50, true, "card_exact")]
+    public void RegisterTableFunctionWithCardinality(int count, bool isExact, string funcName)
     {
-        var expectedData = Enumerable.Range(0, 100).ToList();
+        var expectedData = Enumerable.Range(0, count).ToList();
 
-        Connection.RegisterTableFunction("cardinality_test", parameters =>
+        Connection.RegisterTableFunction(funcName, parameters =>
         {
             return new TableFunction(new List<ColumnInfo>
             {
                 new("value", typeof(int)),
-            }, expectedData, EstimatedCardinality: 100);
+            }, expectedData, Cardinality: new CardinalityHint((ulong)count, IsExact: isExact));
         }, (item, writers, rowIndex) =>
         {
             writers[0].WriteValue((int)item, rowIndex);
         });
 
-        var data = Connection.Query<int>("SELECT * FROM cardinality_test();").ToList();
+        var data = Connection.Query<int>($"SELECT * FROM {funcName}();").ToList();
         data.Should().BeEquivalentTo(expectedData);
     }
 
-    [Fact]
-    public void RegisterTableFunctionWithEstimatedCardinality_AppearsInQueryPlan()
+    [Theory]
+    [InlineData(42, false, "plan_estimated")]
+    [InlineData(50, true, "plan_exact")]
+    public void RegisterTableFunctionWithCardinality_AppearsInQueryPlan(int cardinality, bool isExact, string funcName)
     {
-        Connection.RegisterTableFunction("card_plan", _ =>
+        Connection.RegisterTableFunction(funcName, _ =>
         {
             return new TableFunction(new List<ColumnInfo>
             {
                 new("value", typeof(int)),
-            }, Enumerable.Range(0, 50), EstimatedCardinality: 42);
+            }, Enumerable.Range(0, 50), Cardinality: new CardinalityHint((ulong)cardinality, IsExact: isExact));
         }, (item, writers, rowIndex) =>
         {
             writers[0].WriteValue((int)item, rowIndex);
         });
 
-        var plan = Connection.Query<(string, string)>("EXPLAIN (FORMAT JSON) SELECT * FROM card_plan();").First();
+        var plan = Connection.Query<(string, string)>($"EXPLAIN (FORMAT JSON) SELECT * FROM {funcName}();").First();
         var json = JsonDocument.Parse(plan.Item2);
-        var cardinality = json.RootElement[0]
+        var reported = json.RootElement[0]
             .GetProperty("extra_info")
             .GetProperty("Estimated Cardinality")
             .GetString();
 
-        cardinality.Should().Be("42");
+        reported.Should().Be(cardinality.ToString());
     }
 }

--- a/DuckDB.NET.Test/TableFunctionTests.cs
+++ b/DuckDB.NET.Test/TableFunctionTests.cs
@@ -1,4 +1,5 @@
 ﻿using System.Globalization;
+using System.Text.Json;
 using System.Threading;
 
 namespace DuckDB.NET.Test;
@@ -421,5 +422,49 @@ public class TableFunctionTests(DuckDBDatabaseFixture db) : DuckDBTestBase(db)
         ex.InnerException.Should().BeOfType<NotSupportedException>();
         ex.InnerException!.Message.Should().Be("custom map error");
         ex.InnerException.Should().BeSameAs(originalException);
+    }
+
+    [Fact]
+    public void RegisterTableFunctionWithEstimatedCardinality()
+    {
+        var expectedData = Enumerable.Range(0, 100).ToList();
+
+        Connection.RegisterTableFunction("cardinality_test", parameters =>
+        {
+            return new TableFunction(new List<ColumnInfo>
+            {
+                new("value", typeof(int)),
+            }, expectedData, EstimatedCardinality: 100);
+        }, (item, writers, rowIndex) =>
+        {
+            writers[0].WriteValue((int)item, rowIndex);
+        });
+
+        var data = Connection.Query<int>("SELECT * FROM cardinality_test();").ToList();
+        data.Should().BeEquivalentTo(expectedData);
+    }
+
+    [Fact]
+    public void RegisterTableFunctionWithEstimatedCardinality_AppearsInQueryPlan()
+    {
+        Connection.RegisterTableFunction("card_plan", _ =>
+        {
+            return new TableFunction(new List<ColumnInfo>
+            {
+                new("value", typeof(int)),
+            }, Enumerable.Range(0, 50), EstimatedCardinality: 42);
+        }, (item, writers, rowIndex) =>
+        {
+            writers[0].WriteValue((int)item, rowIndex);
+        });
+
+        var plan = Connection.Query<(string, string)>("EXPLAIN (FORMAT JSON) SELECT * FROM card_plan();").First();
+        var json = JsonDocument.Parse(plan.Item2);
+        var cardinality = json.RootElement[0]
+            .GetProperty("extra_info")
+            .GetProperty("Estimated Cardinality")
+            .GetString();
+
+        cardinality.Should().Be("42");
     }
 }


### PR DESCRIPTION
Adds an optional EstimatedCardinality property to the TableFunction record. When set, the bind callback calls duckdb_bind_set_cardinality to hint the query optimizer. Currently only available through the low-level API where the caller constructs the TableFunction directly. Only estimated (non-exact) cardinality is supported.

Implements #322