### PR TITLE
Update `GetLogicalType()` to support creating a List type for `IList<T>` columns in table functions

### DIFF
--- a/DuckDB.NET.Bindings/NativeMethods/NativeMethods.LogicalType.cs
+++ b/DuckDB.NET.Bindings/NativeMethods/NativeMethods.LogicalType.cs
@@ -9,6 +9,10 @@ public partial class NativeMethods
         [LibraryImport(DuckDbLibrary, EntryPoint = "duckdb_create_logical_type")]
         [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
         public static partial DuckDBLogicalType DuckDBCreateLogicalType(DuckDBType type);
+        
+        [LibraryImport(DuckDbLibrary, EntryPoint = "duckdb_create_list_type")]
+        [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+        public static partial DuckDBLogicalType DuckDBCreateListType(DuckDBLogicalType type);
 
         // Maybe [SuppressGCTransition]: new LogicalType + DecimalType — two small allocations
         [LibraryImport(DuckDbLibrary, EntryPoint = "duckdb_create_decimal_type")]

--- a/DuckDB.NET.Bindings/NativeMethods/NativeMethods.Vectors.cs
+++ b/DuckDB.NET.Bindings/NativeMethods/NativeMethods.Vectors.cs
@@ -50,6 +50,11 @@ public partial class NativeMethods
 		public static partial DuckDBState DuckDBListVectorReserve(IntPtr vector, ulong requiredCapacity);
 
 		[SuppressGCTransition]
+		[LibraryImport(DuckDbLibrary, EntryPoint = "duckdb_list_vector_set_size")]
+		[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+		public static partial DuckDBState DuckDBListVectorSetSize(IntPtr vector, ulong size);
+
+		[SuppressGCTransition]
 		[LibraryImport(DuckDbLibrary, EntryPoint = "duckdb_struct_vector_get_child")]
 		[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
 		public static partial IntPtr DuckDBStructVectorGetChild(IntPtr vector, long index);

--- a/DuckDB.NET.Data/DataChunk/Writer/ListVectorDataWriter.cs
+++ b/DuckDB.NET.Data/DataChunk/Writer/ListVectorDataWriter.cs
@@ -86,6 +86,11 @@ internal sealed unsafe class ListVectorDataWriter : VectorDataWriterBase
 
         offset += count;
 
+        if (IsList)
+        {
+            NativeMethods.Vectors.DuckDBListVectorSetSize(Vector, offset);
+        }
+
         return result;
 
         int WriteItems<T>(IEnumerable<T> items)

--- a/DuckDB.NET.Data/Extensions/TypeExtensions.cs
+++ b/DuckDB.NET.Data/Extensions/TypeExtensions.cs
@@ -89,6 +89,13 @@ internal static class TypeExtensions
             return NativeMethods.LogicalType.DuckDBCreateDecimalType(38, 18);
         }
 
+        if (type.IsAssignableTo(typeof(IList)) && type.IsGenericType)
+        {
+            var genericTypeParameter = type.GetGenericArguments()[0];
+            using var nestedType = genericTypeParameter.GetLogicalType();
+            return NativeMethods.LogicalType.DuckDBCreateListType(nestedType);
+        }
+
         if (ClrToDuckDBTypeMap.TryGetValue(type, out var duckDBType))
         {
             return NativeMethods.LogicalType.DuckDBCreateLogicalType(duckDBType);

--- a/DuckDB.NET.Test/TableFunctionTests.cs
+++ b/DuckDB.NET.Test/TableFunctionTests.cs
@@ -471,4 +471,107 @@ public class TableFunctionTests(DuckDBDatabaseFixture db) : DuckDBTestBase(db)
 
         reported.Should().Be(cardinality.ToString());
     }
+
+    [Fact]
+    public void RegisterTableFunctionWithListColumn()
+    {
+        var sourceData = new List<List<int>>
+        {
+            new() { 1, 2, 3 },
+            new() { 4, 5 },
+            new() { },
+            null,
+        };
+
+        Connection.RegisterTableFunction("list_func", () =>
+        {
+            return new TableFunction(new List<ColumnInfo>
+            {
+                new("numbers", typeof(List<int>)),
+            }, sourceData);
+        }, (item, writers, rowIndex) =>
+        {
+            writers[0].WriteValue((List<int>)item, rowIndex);
+        });
+
+        using var command = Connection.CreateCommand();
+        command.CommandText = "SELECT numbers FROM list_func();";
+        using var reader = command.ExecuteReader();
+
+        reader.Read();
+        reader.GetFieldValue<List<int>>(0).Should().BeEquivalentTo(new List<int> { 1, 2, 3 });
+
+        reader.Read();
+        reader.GetFieldValue<List<int>>(0).Should().BeEquivalentTo(new List<int> { 4, 5 });
+
+        reader.Read();
+        reader.GetFieldValue<List<int>>(0).Should().BeEquivalentTo(new List<int>());
+
+        reader.Read();
+        reader.IsDBNull(0).Should().BeTrue();
+
+        reader.Read().Should().BeFalse();
+    }
+
+    [Fact]
+    public void RegisterTableFunctionWithListColumn_ListHasAny()
+    {
+        var sourceData = new List<List<int>>
+        {
+            new() { 1, 2, 3 },
+            new() { 4, 5 },
+            new() { 6, 7, 8, 9 },
+            new() { },
+        };
+
+        Connection.RegisterTableFunction("list_func_has_any", () =>
+        {
+            return new TableFunction(new List<ColumnInfo>
+            {
+                new("numbers", typeof(List<int>)),
+            }, sourceData);
+        }, (item, writers, rowIndex) =>
+        {
+            writers[0].WriteValue((List<int>)item, rowIndex);
+        });
+
+        var data = Connection.Query<bool>("SELECT list_has_any(numbers, [3]) FROM list_func_has_any();").ToList();
+        data.Should().BeEquivalentTo([true, false, false, false]);
+    }
+
+    [Fact]
+    public void RegisterTableFunctionWithNestedListColumn()
+    {
+        var sourceData = new List<List<List<int?>>>
+        {
+            new() { new() { 1, 2 }, new() { 3, null, 5 } },
+            new() { new() { 10 }, null, new() { 20, 30 }, new() { 40 } },
+        };
+
+        Connection.RegisterTableFunction("list_func_nested", () =>
+        {
+            return new TableFunction(new List<ColumnInfo>
+            {
+                new("nested", typeof(List<List<int?>>)),
+            }, sourceData);
+        }, (item, writers, rowIndex) =>
+        {
+            writers[0].WriteValue((List<List<int?>>)item, rowIndex);
+        });
+
+        // flatten reduces one level of nesting
+        using var command = Connection.CreateCommand();
+        command.CommandText = "SELECT flatten(nested) FROM list_func_nested();";
+        using var reader = command.ExecuteReader();
+
+        reader.Read();
+        reader.GetFieldValue<List<int?>>(0).Should().BeEquivalentTo([1, 2, 3, (int?)null, 5],
+            options => options.WithStrictOrdering());
+
+        reader.Read();
+        reader.GetFieldValue<List<int?>>(0).Should().BeEquivalentTo([10, 20, 30, 40],
+            options => options.WithStrictOrdering());
+
+        reader.Read().Should().BeFalse();
+    }
 }


### PR DESCRIPTION
Also fixes crash when DuckDB-internal list functions (e.g. `list_has_any`) operate on list columns from table functions. The root cause was that `duckdb_list_vector_set_size` was never called after writing child elements, so DuckDB didn't know the actual size of the child vector. Simple reads worked, but functions that presumably inspect the child vector's reported size would crash.