### PR TITLE
Add Apache Arrow result streaming to DuckDBCommand

### DIFF
--- a/DuckDB.NET.Bindings/DuckDBWrapperObjects.cs
+++ b/DuckDB.NET.Bindings/DuckDBWrapperObjects.cs
@@ -77,6 +77,19 @@ public class DuckDBArrowOptions() : SafeHandleZeroOrMinusOneIsInvalid(true)
     }
 }
 
+public class DuckDBErrorData() : SafeHandleZeroOrMinusOneIsInvalid(true)
+{
+    public bool HasError => !IsInvalid && NativeMethods.ErrorData.DuckDBErrorDataHasError(this);
+
+    public string? Message => IsInvalid ? null : NativeMethods.ErrorData.DuckDBErrorDataMessage(this);
+
+    protected override bool ReleaseHandle()
+    {
+        NativeMethods.ErrorData.DuckDBDestroyErrorData(ref handle);
+        return true;
+    }
+}
+
 public class DuckDBDataChunk : SafeHandleZeroOrMinusOneIsInvalid
 {
     public DuckDBDataChunk() : base(true)

--- a/DuckDB.NET.Bindings/DuckDBWrapperObjects.cs
+++ b/DuckDB.NET.Bindings/DuckDBWrapperObjects.cs
@@ -68,6 +68,15 @@ public class DuckDBLogicalType() : SafeHandleZeroOrMinusOneIsInvalid(true)
     }
 }
 
+public class DuckDBArrowOptions() : SafeHandleZeroOrMinusOneIsInvalid(true)
+{
+    protected override bool ReleaseHandle()
+    {
+        NativeMethods.Arrow.DuckDBDestroyArrowOptions(ref handle);
+        return true;
+    }
+}
+
 public class DuckDBDataChunk : SafeHandleZeroOrMinusOneIsInvalid
 {
     public DuckDBDataChunk() : base(true)

--- a/DuckDB.NET.Bindings/NativeMethods/NativeMethods.Arrow.cs
+++ b/DuckDB.NET.Bindings/NativeMethods/NativeMethods.Arrow.cs
@@ -1,0 +1,42 @@
+namespace DuckDB.NET.Native;
+
+public partial class NativeMethods
+{
+    //https://duckdb.org/docs/stable/clients/c/api#arrow-interface
+    public static partial class Arrow
+    {
+        [LibraryImport(DuckDbLibrary, EntryPoint = "duckdb_result_get_arrow_options")]
+        [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+        public static partial DuckDBArrowOptions DuckDBResultGetArrowOptions(ref DuckDBResult result);
+
+        [LibraryImport(DuckDbLibrary, EntryPoint = "duckdb_destroy_arrow_options")]
+        [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+        public static partial void DuckDBDestroyArrowOptions(ref IntPtr arrowOptions);
+
+        // duckdb_error_data duckdb_to_arrow_schema(duckdb_arrow_options, duckdb_logical_type *types,
+        //                                          const char **names, idx_t column_count, ArrowSchema *out_schema)
+        [LibraryImport(DuckDbLibrary, EntryPoint = "duckdb_to_arrow_schema")]
+        [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+        public static partial IntPtr DuckDBToArrowSchema(DuckDBArrowOptions arrowOptions, IntPtr types, IntPtr names, ulong columnCount, IntPtr outSchema);
+
+        // duckdb_error_data duckdb_data_chunk_to_arrow(duckdb_arrow_options, duckdb_data_chunk, ArrowArray *out_arrow_array)
+        [LibraryImport(DuckDbLibrary, EntryPoint = "duckdb_data_chunk_to_arrow")]
+        [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+        public static partial IntPtr DuckDBDataChunkToArrow(DuckDBArrowOptions arrowOptions, DuckDBDataChunk chunk, IntPtr outArray);
+
+        [SuppressGCTransition]
+        [LibraryImport(DuckDbLibrary, EntryPoint = "duckdb_error_data_has_error")]
+        [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+        [return: MarshalAs(UnmanagedType.I1)]
+        public static partial bool DuckDBErrorDataHasError(IntPtr errorData);
+
+        [LibraryImport(DuckDbLibrary, EntryPoint = "duckdb_error_data_message")]
+        [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+        [return: MarshalUsing(typeof(DuckDBOwnedStringMarshaller))]
+        public static partial string DuckDBErrorDataMessage(IntPtr errorData);
+
+        [LibraryImport(DuckDbLibrary, EntryPoint = "duckdb_destroy_error_data")]
+        [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+        public static partial void DuckDBDestroyErrorData(ref IntPtr errorData);
+    }
+}

--- a/DuckDB.NET.Bindings/NativeMethods/NativeMethods.Arrow.cs
+++ b/DuckDB.NET.Bindings/NativeMethods/NativeMethods.Arrow.cs
@@ -17,26 +17,11 @@ public partial class NativeMethods
         //                                          const char **names, idx_t column_count, ArrowSchema *out_schema)
         [LibraryImport(DuckDbLibrary, EntryPoint = "duckdb_to_arrow_schema")]
         [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-        public static partial IntPtr DuckDBToArrowSchema(DuckDBArrowOptions arrowOptions, IntPtr types, IntPtr names, ulong columnCount, IntPtr outSchema);
+        public static partial DuckDBErrorData DuckDBToArrowSchema(DuckDBArrowOptions arrowOptions, IntPtr types, IntPtr names, ulong columnCount, IntPtr outSchema);
 
         // duckdb_error_data duckdb_data_chunk_to_arrow(duckdb_arrow_options, duckdb_data_chunk, ArrowArray *out_arrow_array)
         [LibraryImport(DuckDbLibrary, EntryPoint = "duckdb_data_chunk_to_arrow")]
         [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-        public static partial IntPtr DuckDBDataChunkToArrow(DuckDBArrowOptions arrowOptions, DuckDBDataChunk chunk, IntPtr outArray);
-
-        [SuppressGCTransition]
-        [LibraryImport(DuckDbLibrary, EntryPoint = "duckdb_error_data_has_error")]
-        [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-        [return: MarshalAs(UnmanagedType.I1)]
-        public static partial bool DuckDBErrorDataHasError(IntPtr errorData);
-
-        [LibraryImport(DuckDbLibrary, EntryPoint = "duckdb_error_data_message")]
-        [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-        [return: MarshalUsing(typeof(DuckDBOwnedStringMarshaller))]
-        public static partial string DuckDBErrorDataMessage(IntPtr errorData);
-
-        [LibraryImport(DuckDbLibrary, EntryPoint = "duckdb_destroy_error_data")]
-        [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-        public static partial void DuckDBDestroyErrorData(ref IntPtr errorData);
+        public static partial DuckDBErrorData DuckDBDataChunkToArrow(DuckDBArrowOptions arrowOptions, DuckDBDataChunk chunk, IntPtr outArray);
     }
 }

--- a/DuckDB.NET.Bindings/NativeMethods/NativeMethods.ErrorData.cs
+++ b/DuckDB.NET.Bindings/NativeMethods/NativeMethods.ErrorData.cs
@@ -1,0 +1,23 @@
+namespace DuckDB.NET.Native;
+
+public partial class NativeMethods
+{
+    //https://duckdb.org/docs/stable/clients/c/api#error-data
+    public static partial class ErrorData
+    {
+        [SuppressGCTransition]
+        [LibraryImport(DuckDbLibrary, EntryPoint = "duckdb_error_data_has_error")]
+        [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+        [return: MarshalAs(UnmanagedType.I1)]
+        public static partial bool DuckDBErrorDataHasError(DuckDBErrorData errorData);
+
+        [LibraryImport(DuckDbLibrary, EntryPoint = "duckdb_error_data_message")]
+        [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+        [return: MarshalUsing(typeof(DuckDBOwnedStringMarshaller))]
+        public static partial string DuckDBErrorDataMessage(DuckDBErrorData errorData);
+
+        [LibraryImport(DuckDbLibrary, EntryPoint = "duckdb_destroy_error_data")]
+        [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+        public static partial void DuckDBDestroyErrorData(ref IntPtr errorData);
+    }
+}

--- a/DuckDB.NET.Data/Arrow/DuckDBArrowArrayStream.cs
+++ b/DuckDB.NET.Data/Arrow/DuckDBArrowArrayStream.cs
@@ -13,7 +13,7 @@ namespace DuckDB.NET.Data.Arrow;
 /// DuckDB's Arrow C Data Interface (<c>duckdb_to_arrow_schema</c> / <c>duckdb_data_chunk_to_arrow</c>).
 /// Each DuckDB data chunk is converted into one Arrow record batch and imported with no row-by-row marshaling.
 /// </summary>
-public sealed class DuckDBArrowArrayStream : IArrowArrayStream
+internal sealed class DuckDBArrowArrayStream : IArrowArrayStream
 {
     private DuckDBResult result;
     private readonly DuckDBArrowOptions arrowOptions;
@@ -75,7 +75,7 @@ public sealed class DuckDBArrowArrayStream : IArrowArrayStream
                 fixed (IntPtr* namesPointer = namePointers)
                 {
                     var error = NativeMethods.Arrow.DuckDBToArrowSchema(arrowOptions, (IntPtr)typesPointer, (IntPtr)namesPointer, columnCount, (IntPtr)cSchema);
-                    ThrowIfError(error, "Failed to convert the DuckDB result schema to an Arrow schema.");
+                    error.ThrowOnError("Failed to convert the DuckDB result schema to an Arrow schema.");
                 }
 
                 return CArrowSchemaImporter.ImportSchema(cSchema);
@@ -138,34 +138,13 @@ public sealed class DuckDBArrowArrayStream : IArrowArrayStream
         try
         {
             var error = NativeMethods.Arrow.DuckDBDataChunkToArrow(arrowOptions, chunk, (IntPtr)cArray);
-            ThrowIfError(error, "Failed to convert a DuckDB data chunk to an Arrow array.");
+            error.ThrowOnError("Failed to convert a DuckDB data chunk to an Arrow array.");
 
             return CArrowArrayImporter.ImportRecordBatch(cArray, Schema);
         }
         finally
         {
             CArrowArray.Free(cArray);
-        }
-    }
-
-    private static void ThrowIfError(IntPtr errorData, string message)
-    {
-        if (errorData == IntPtr.Zero)
-        {
-            return;
-        }
-
-        try
-        {
-            if (NativeMethods.Arrow.DuckDBErrorDataHasError(errorData))
-            {
-                var detail = NativeMethods.Arrow.DuckDBErrorDataMessage(errorData);
-                throw new InvalidOperationException($"{message} {detail}".TrimEnd());
-            }
-        }
-        finally
-        {
-            NativeMethods.Arrow.DuckDBDestroyErrorData(ref errorData);
         }
     }
 

--- a/DuckDB.NET.Data/Arrow/DuckDBArrowArrayStream.cs
+++ b/DuckDB.NET.Data/Arrow/DuckDBArrowArrayStream.cs
@@ -1,0 +1,170 @@
+using System.Runtime.InteropServices;
+using System.Threading;
+using System.Threading.Tasks;
+using Apache.Arrow;
+using Apache.Arrow.C;
+using Apache.Arrow.Ipc;
+using DuckDB.NET.Native;
+
+namespace DuckDB.NET.Data.Arrow;
+
+/// <summary>
+/// Streams the rows of a DuckDB query result as Apache Arrow <see cref="RecordBatch"/> values using
+/// DuckDB's Arrow C Data Interface (<c>duckdb_to_arrow_schema</c> / <c>duckdb_data_chunk_to_arrow</c>).
+/// Each DuckDB data chunk is converted into one Arrow record batch and imported with no row-by-row marshaling.
+/// </summary>
+public sealed class DuckDBArrowArrayStream : IArrowArrayStream
+{
+    private DuckDBResult result;
+    private readonly DuckDBArrowOptions arrowOptions;
+    private bool disposed;
+
+    public Schema Schema { get; }
+
+    internal DuckDBArrowArrayStream(DuckDBResult result)
+    {
+        this.result = result;
+
+        arrowOptions = NativeMethods.Arrow.DuckDBResultGetArrowOptions(ref this.result);
+        if (arrowOptions.IsInvalid)
+        {
+            this.result.Close();
+            throw new InvalidOperationException("Failed to obtain Arrow options from the DuckDB result.");
+        }
+
+        Schema = BuildSchema();
+    }
+
+    private unsafe Schema BuildSchema()
+    {
+        var columnCount = NativeMethods.Query.DuckDBColumnCount(ref result);
+
+        var logicalTypes = new DuckDBLogicalType[columnCount];
+        var typeHandles = new IntPtr[columnCount];
+        var namePointers = new IntPtr[columnCount];
+
+        try
+        {
+            for (var index = 0UL; index < columnCount; index++)
+            {
+                var logicalType = NativeMethods.Query.DuckDBColumnLogicalType(ref result, (long)index);
+                logicalTypes[index] = logicalType;
+                typeHandles[index] = logicalType.DangerousGetHandle();
+
+                var name = NativeMethods.Query.DuckDBColumnName(ref result, (long)index);
+                namePointers[index] = Marshal.StringToCoTaskMemUTF8(name);
+            }
+
+            var cSchema = CArrowSchema.Create();
+
+            try
+            {
+                fixed (IntPtr* typesPointer = typeHandles)
+                fixed (IntPtr* namesPointer = namePointers)
+                {
+                    var error = NativeMethods.Arrow.DuckDBToArrowSchema(arrowOptions, (IntPtr)typesPointer, (IntPtr)namesPointer, columnCount, (IntPtr)cSchema);
+                    ThrowIfError(error, "Failed to convert the DuckDB result schema to an Arrow schema.");
+                }
+
+                return CArrowSchemaImporter.ImportSchema(cSchema);
+            }
+            finally
+            {
+                CArrowSchema.Free(cSchema);
+            }
+        }
+        finally
+        {
+            foreach (var pointer in namePointers)
+            {
+                if (pointer != IntPtr.Zero)
+                {
+                    Marshal.FreeCoTaskMem(pointer);
+                }
+            }
+
+            foreach (var logicalType in logicalTypes)
+            {
+                logicalType?.Dispose();
+            }
+        }
+    }
+
+    public ValueTask<RecordBatch?> ReadNextRecordBatchAsync(CancellationToken cancellationToken = default)
+    {
+        ObjectDisposedException.ThrowIf(disposed, this);
+
+        if (cancellationToken.IsCancellationRequested)
+        {
+            return new ValueTask<RecordBatch?>(Task.FromCanceled<RecordBatch?>(cancellationToken));
+        }
+
+        var chunk = NativeMethods.Query.DuckDBFetchChunk(result);
+
+        if (chunk.IsInvalid)
+        {
+            chunk.Dispose();
+            return new ValueTask<RecordBatch?>((RecordBatch?)null);
+        }
+
+        try
+        {
+            return new ValueTask<RecordBatch?>(ConvertChunk(chunk));
+        }
+        finally
+        {
+            chunk.Dispose();
+        }
+    }
+
+    private unsafe RecordBatch ConvertChunk(DuckDBDataChunk chunk)
+    {
+        var cArray = CArrowArray.Create();
+
+        try
+        {
+            var error = NativeMethods.Arrow.DuckDBDataChunkToArrow(arrowOptions, chunk, (IntPtr)cArray);
+            ThrowIfError(error, "Failed to convert a DuckDB data chunk to an Arrow array.");
+
+            return CArrowArrayImporter.ImportRecordBatch(cArray, Schema);
+        }
+        finally
+        {
+            CArrowArray.Free(cArray);
+        }
+    }
+
+    private static void ThrowIfError(IntPtr errorData, string message)
+    {
+        if (errorData == IntPtr.Zero)
+        {
+            return;
+        }
+
+        try
+        {
+            if (NativeMethods.Arrow.DuckDBErrorDataHasError(errorData))
+            {
+                var detail = NativeMethods.Arrow.DuckDBErrorDataMessage(errorData);
+                throw new InvalidOperationException($"{message} {detail}".TrimEnd());
+            }
+        }
+        finally
+        {
+            NativeMethods.Arrow.DuckDBDestroyErrorData(ref errorData);
+        }
+    }
+
+    public void Dispose()
+    {
+        if (disposed)
+        {
+            return;
+        }
+
+        disposed = true;
+
+        arrowOptions.Dispose();
+        result.Close();
+    }
+}

--- a/DuckDB.NET.Data/Arrow/DuckDBArrowArrayStream.cs
+++ b/DuckDB.NET.Data/Arrow/DuckDBArrowArrayStream.cs
@@ -17,6 +17,7 @@ public sealed class DuckDBArrowArrayStream : IArrowArrayStream
 {
     private DuckDBResult result;
     private readonly DuckDBArrowOptions arrowOptions;
+    private readonly bool streaming;
     private bool disposed;
 
     public Schema Schema { get; }
@@ -32,7 +33,18 @@ public sealed class DuckDBArrowArrayStream : IArrowArrayStream
             throw new InvalidOperationException("Failed to obtain Arrow options from the DuckDB result.");
         }
 
-        Schema = BuildSchema();
+        streaming = NativeMethods.Types.DuckDBResultIsStreaming(this.result) > 0;
+
+        try
+        {
+            Schema = BuildSchema();
+        }
+        catch
+        {
+            arrowOptions.Dispose();
+            this.result.Close();
+            throw;
+        }
     }
 
     private unsafe Schema BuildSchema()
@@ -99,7 +111,9 @@ public sealed class DuckDBArrowArrayStream : IArrowArrayStream
             return new ValueTask<RecordBatch?>(Task.FromCanceled<RecordBatch?>(cancellationToken));
         }
 
-        var chunk = NativeMethods.Query.DuckDBFetchChunk(result);
+        var chunk = streaming
+            ? NativeMethods.StreamingResult.DuckDBStreamFetchChunk(result)
+            : NativeMethods.Query.DuckDBFetchChunk(result);
 
         if (chunk.IsInvalid)
         {

--- a/DuckDB.NET.Data/Data.csproj
+++ b/DuckDB.NET.Data/Data.csproj
@@ -32,6 +32,10 @@ New features:
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Apache.Arrow" Version="23.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\DuckDB.NET.Bindings\Bindings.csproj" />
   </ItemGroup>
 

--- a/DuckDB.NET.Data/DuckDBCommand.cs
+++ b/DuckDB.NET.Data/DuckDBCommand.cs
@@ -1,6 +1,11 @@
 ﻿using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+using Apache.Arrow;
+using Apache.Arrow.Ipc;
+using DuckDB.NET.Data.Arrow;
 
 namespace DuckDB.NET.Data;
 
@@ -107,6 +112,54 @@ public class DuckDBCommand : DbCommand
         var reader = new DuckDBDataReader(this, results, behavior);
 
         return reader;
+    }
+
+    /// <summary>
+    /// Executes the command and returns the first result set as an Apache Arrow
+    /// <see cref="IArrowArrayStream"/>. Each DuckDB data chunk is converted to an Arrow record batch
+    /// using DuckDB's Arrow C Data Interface, with no row-by-row marshaling.
+    /// The caller owns the returned stream and must dispose it.
+    /// </summary>
+    public IArrowArrayStream ExecuteArrowStream()
+    {
+        EnsureConnectionOpen();
+
+        var results = PreparedStatement.PreparedStatement.PrepareMultiple(connection!.NativeConnection, CommandText, parameters, useStreamingMode: false);
+
+        foreach (var result in results)
+        {
+            var current = result;
+
+            if (NativeMethods.Query.DuckDBResultReturnType(current) == DuckDBResultType.QueryResult)
+            {
+                return new DuckDBArrowArrayStream(current);
+            }
+
+            current.Close();
+        }
+
+        throw new InvalidOperationException("The command did not return a result set.");
+    }
+
+    /// <summary>
+    /// Executes the command and asynchronously streams the first result set as Apache Arrow
+    /// <see cref="RecordBatch"/> values. The batches are produced lazily, one per DuckDB data chunk.
+    /// </summary>
+    public async IAsyncEnumerable<RecordBatch> ExecuteArrowBatchesAsync([EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        var stream = ExecuteArrowStream();
+
+        try
+        {
+            while (await stream.ReadNextRecordBatchAsync(cancellationToken).ConfigureAwait(false) is { } batch)
+            {
+                yield return batch;
+            }
+        }
+        finally
+        {
+            stream.Dispose();
+        }
     }
 
     public override void Prepare() { }

--- a/DuckDB.NET.Data/DuckDBCommand.cs
+++ b/DuckDB.NET.Data/DuckDBCommand.cs
@@ -118,13 +118,15 @@ public class DuckDBCommand : DbCommand
     /// Executes the command and returns the first result set as an Apache Arrow
     /// <see cref="IArrowArrayStream"/>. Each DuckDB data chunk is converted to an Arrow record batch
     /// using DuckDB's Arrow C Data Interface, with no row-by-row marshaling.
+    /// When <see cref="UseStreamingMode"/> is enabled, record batches are produced lazily from a
+    /// streaming result (bounded memory), otherwise the result is materialized first.
     /// The caller owns the returned stream and must dispose it.
     /// </summary>
     public IArrowArrayStream ExecuteArrowStream()
     {
         EnsureConnectionOpen();
 
-        var results = PreparedStatement.PreparedStatement.PrepareMultiple(connection!.NativeConnection, CommandText, parameters, useStreamingMode: false);
+        var results = PreparedStatement.PreparedStatement.PrepareMultiple(connection!.NativeConnection, CommandText, parameters, UseStreamingMode);
 
         foreach (var result in results)
         {
@@ -144,6 +146,7 @@ public class DuckDBCommand : DbCommand
     /// <summary>
     /// Executes the command and asynchronously streams the first result set as Apache Arrow
     /// <see cref="RecordBatch"/> values. The batches are produced lazily, one per DuckDB data chunk.
+    /// Set <see cref="UseStreamingMode"/> to stream from a streaming result with bounded memory.
     /// </summary>
     public async IAsyncEnumerable<RecordBatch> ExecuteArrowBatchesAsync([EnumeratorCancellation] CancellationToken cancellationToken = default)
     {

--- a/DuckDB.NET.Data/Extensions/DuckDBErrorDataExtensions.cs
+++ b/DuckDB.NET.Data/Extensions/DuckDBErrorDataExtensions.cs
@@ -1,0 +1,15 @@
+namespace DuckDB.NET.Data.Extensions;
+
+internal static class DuckDBErrorDataExtensions
+{
+    public static void ThrowOnError(this DuckDBErrorData errorData, string message)
+    {
+        using (errorData)
+        {
+            if (errorData.HasError)
+            {
+                throw new DuckDBException($"{message} {errorData.Message}".TrimEnd());
+            }
+        }
+    }
+}

--- a/DuckDB.NET.Test/Arrow/ArrowResultTests.cs
+++ b/DuckDB.NET.Test/Arrow/ArrowResultTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Threading;
 using Apache.Arrow;
 using Apache.Arrow.Types;
@@ -6,9 +7,12 @@ namespace DuckDB.NET.Test.Arrow;
 
 public class ArrowResultTests(DuckDBDatabaseFixture db) : DuckDBTestBase(db)
 {
-    [Fact]
-    public async Task ExecuteArrowBatches_ReturnsSchemaAndScalarValues()
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task ExecuteArrowBatches_ReturnsSchemaAndScalarValues(bool useStreamingMode)
     {
+        Command.UseStreamingMode = useStreamingMode;
         Command.CommandText = "select 42 as answer, 'duckdb' as name, cast(3.5 as double) as ratio";
 
         var batches = await ReadAllAsync();
@@ -26,9 +30,12 @@ public class ArrowResultTests(DuckDBDatabaseFixture db) : DuckDBTestBase(db)
         DisposeBatches(batches);
     }
 
-    [Fact]
-    public async Task ExecuteArrowBatches_HandlesNullValues()
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task ExecuteArrowBatches_HandlesNullValues(bool useStreamingMode)
     {
+        Command.UseStreamingMode = useStreamingMode;
         Command.CommandText = "select unnest([1, null, 3]) as value";
 
         var batches = await ReadAllAsync();
@@ -42,10 +49,13 @@ public class ArrowResultTests(DuckDBDatabaseFixture db) : DuckDBTestBase(db)
         DisposeBatches(batches);
     }
 
-    [Fact]
-    public async Task ExecuteArrowBatches_StreamsMultipleChunks()
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task ExecuteArrowBatches_StreamsMultipleChunks(bool useStreamingMode)
     {
         const int rowCount = 5000;
+        Command.UseStreamingMode = useStreamingMode;
         Command.CommandText = $"select i from range({rowCount}) t(i)";
 
         var batches = await ReadAllAsync();
@@ -105,6 +115,44 @@ public class ArrowResultTests(DuckDBDatabaseFixture db) : DuckDBTestBase(db)
         var act = () => Command.ExecuteArrowStream();
 
         act.Should().Throw<InvalidOperationException>();
+    }
+
+    [Fact]
+    public async Task ReadNextRecordBatchAsync_WithCanceledToken_ReturnsCanceledTask()
+    {
+        Command.CommandText = "select i from range(10) t(i)";
+
+        using var stream = Command.ExecuteArrowStream();
+
+        var act = async () => await stream.ReadNextRecordBatchAsync(new CancellationToken(canceled: true));
+
+        await act.Should().ThrowAsync<OperationCanceledException>();
+    }
+
+    [Fact]
+    public async Task ReadNextRecordBatchAsync_AfterDispose_Throws()
+    {
+        Command.CommandText = "select i from range(10) t(i)";
+
+        var stream = Command.ExecuteArrowStream();
+        stream.Dispose();
+
+        var act = async () => await stream.ReadNextRecordBatchAsync(CancellationToken.None);
+
+        await act.Should().ThrowAsync<ObjectDisposedException>();
+    }
+
+    [Fact]
+    public void Dispose_CalledTwice_IsNoOp()
+    {
+        Command.CommandText = "select i from range(10) t(i)";
+
+        var stream = Command.ExecuteArrowStream();
+
+        stream.Dispose();
+        var act = () => stream.Dispose();
+
+        act.Should().NotThrow();
     }
 
     private async Task<List<RecordBatch>> ReadAllAsync()

--- a/DuckDB.NET.Test/Arrow/ArrowResultTests.cs
+++ b/DuckDB.NET.Test/Arrow/ArrowResultTests.cs
@@ -1,0 +1,128 @@
+using System.Threading;
+using Apache.Arrow;
+using Apache.Arrow.Types;
+
+namespace DuckDB.NET.Test.Arrow;
+
+public class ArrowResultTests(DuckDBDatabaseFixture db) : DuckDBTestBase(db)
+{
+    [Fact]
+    public async Task ExecuteArrowBatches_ReturnsSchemaAndScalarValues()
+    {
+        Command.CommandText = "select 42 as answer, 'duckdb' as name, cast(3.5 as double) as ratio";
+
+        var batches = await ReadAllAsync();
+
+        batches.Should().ContainSingle();
+
+        var batch = batches[0];
+        batch.Schema.FieldsList.Select(f => f.Name).Should().Equal("answer", "name", "ratio");
+        batch.Length.Should().Be(1);
+
+        ((Int32Array)batch.Column("answer")).GetValue(0).Should().Be(42);
+        ((StringArray)batch.Column("name")).GetString(0).Should().Be("duckdb");
+        ((DoubleArray)batch.Column("ratio")).GetValue(0).Should().Be(3.5);
+
+        DisposeBatches(batches);
+    }
+
+    [Fact]
+    public async Task ExecuteArrowBatches_HandlesNullValues()
+    {
+        Command.CommandText = "select unnest([1, null, 3]) as value";
+
+        var batches = await ReadAllAsync();
+
+        var column = (Int32Array)batches.Single().Column("value");
+        column.Length.Should().Be(3);
+        column.GetValue(0).Should().Be(1);
+        column.GetValue(1).Should().BeNull();
+        column.GetValue(2).Should().Be(3);
+
+        DisposeBatches(batches);
+    }
+
+    [Fact]
+    public async Task ExecuteArrowBatches_StreamsMultipleChunks()
+    {
+        const int rowCount = 5000;
+        Command.CommandText = $"select i from range({rowCount}) t(i)";
+
+        var batches = await ReadAllAsync();
+
+        batches.Count.Should().BeGreaterThan(1);
+        batches.Sum(b => b.Length).Should().Be(rowCount);
+
+        var total = 0L;
+        foreach (var batch in batches)
+        {
+            var column = (Int64Array)batch.Column("i");
+            for (var row = 0; row < column.Length; row++)
+            {
+                total += column.GetValue(row)!.Value;
+            }
+        }
+
+        total.Should().Be((long)rowCount * (rowCount - 1) / 2);
+
+        DisposeBatches(batches);
+    }
+
+    [Fact]
+    public void ExecuteArrowStream_ExposesSchemaWithoutReading()
+    {
+        Command.CommandText = "select 1 as a, 'x' as b";
+
+        using var stream = Command.ExecuteArrowStream();
+
+        stream.Schema.FieldsList.Select(f => f.Name).Should().Equal("a", "b");
+        stream.Schema.GetFieldByName("a").DataType.TypeId.Should().Be(ArrowTypeId.Int32);
+        stream.Schema.GetFieldByName("b").DataType.TypeId.Should().Be(ArrowTypeId.String);
+    }
+
+    [Fact]
+    public async Task ExecuteArrowStream_ReadsBatchesUntilNull()
+    {
+        Command.CommandText = "select i from range(10) t(i)";
+
+        using var stream = Command.ExecuteArrowStream();
+
+        var rows = 0;
+        while (await stream.ReadNextRecordBatchAsync(CancellationToken.None) is { } batch)
+        {
+            rows += batch.Length;
+            batch.Dispose();
+        }
+
+        rows.Should().Be(10);
+    }
+
+    [Fact]
+    public void ExecuteArrowStream_ThrowsWhenNoResultSet()
+    {
+        Command.CommandText = "create table t_no_result (id integer)";
+
+        var act = () => Command.ExecuteArrowStream();
+
+        act.Should().Throw<InvalidOperationException>();
+    }
+
+    private async Task<List<RecordBatch>> ReadAllAsync()
+    {
+        var batches = new List<RecordBatch>();
+        await foreach (var batch in Command.ExecuteArrowBatchesAsync())
+        {
+            batches.Add(batch);
+        }
+
+        return batches;
+    }
+
+    private static void DisposeBatches(List<RecordBatch> batches)
+    {
+        foreach (var batch in batches)
+        {
+            batch.Dispose();
+        }
+    }
+}


### PR DESCRIPTION
## What's Changed

Adds a managed Apache Arrow read surface to `DuckDB.NET.Data`, addressing #26. It is built on DuckDB's **current** Arrow C Data Interface (`duckdb_to_arrow_schema` / `duckdb_data_chunk_to_arrow`), not the deprecated `duckdb_query_arrow` family, so it should keep working as the legacy API is removed.

Two new APIs on `DuckDBCommand`:

```csharp
// Friendly async path
await using var command = connection.CreateCommand();
command.CommandText = "select 42 as answer, 'duckdb' as name";

await foreach (RecordBatch batch in command.ExecuteArrowBatchesAsync(cancellationToken))
{
    // consume Apache.Arrow RecordBatch values
}

// Lower-level interop path
using IArrowArrayStream stream = command.ExecuteArrowStream();
```

### How it works

- **Bindings** (`DuckDB.NET.Bindings`): adds `duckdb_result_get_arrow_options`, `duckdb_to_arrow_schema`, `duckdb_data_chunk_to_arrow`, the `duckdb_error_data` accessors, and a `DuckDBArrowOptions` safe handle.
- **Data** (`DuckDB.NET.Data`): a `DuckDBArrowArrayStream : IArrowArrayStream` builds the `ArrowSchema` once from the result column types/names, then loops `duckdb_fetch_chunk` and converts each chunk into an Arrow `RecordBatch`. The native `ArrowSchema` / `ArrowArray` structs are handed straight to `Apache.Arrow.C.CArrowSchemaImporter.ImportSchema` and `CArrowArrayImporter.ImportRecordBatch`, so all type mapping is delegated to DuckDB's own converter (no per-type C# code).
- The `Apache.Arrow` package dependency lives in `DuckDB.NET.Data` only; `DuckDB.NET.Bindings` stays free of it.

### Open question

The main thing to confirm is **where the `Apache.Arrow` dependency should sit**. This PR puts it in `DuckDB.NET.Data`, with `Bindings` only exposing the native structs/functions. Happy to move it if you would prefer a separate package (e.g. `DuckDB.NET.Data.Arrow`) so that callers who do not need Arrow do not take the dependency.

### Scope

In scope (this PR):
- Read path, DuckDB result -> Arrow, for the first result set of a command.

Deferred (follow-ups if the direction is welcome):
- Arrow ingest/scan (Arrow -> DuckDB).
- Multiple result sets from a single multi-statement command.

### Tests

Adds `ArrowResultTests` covering schema shape, scalar values, nulls, multi-chunk streaming (`range(5000)` yields multiple batches), and the `ExecuteArrowStream()` path. The full existing suite (6886 tests) still passes locally.

Opening as a **draft** pending your call on the dependency-location question above.
