### PR TITLE
Skip Convert.ChangeType on the same-type object read path

### DIFF
--- a/DuckDB.NET.Data/DataChunk/Reader/NumericVectorDataReader.cs
+++ b/DuckDB.NET.Data/DataChunk/Reader/NumericVectorDataReader.cs
@@ -71,6 +71,15 @@ internal sealed class NumericVectorDataReader : VectorDataReaderBase
             _ => base.GetValue(offset, targetType)
         };
 
+        // Fast path: when the boxed value already has the requested type (the common case for
+        // GetValue(ordinal)/this[ordinal], which read using the column's natural ClrType), skip the
+        // Convert.ChangeType machinery entirely. ChangeType does not early-out on same-type for
+        // IConvertible values — it re-boxes via ToXxx() — so this also removes a redundant box.
+        if (value.GetType() == targetType)
+        {
+            return value;
+        }
+
         if (targetType.IsNumeric())
         {
             try


### PR DESCRIPTION
## What's Changed

`NumericVectorDataReader.GetValue(offset, targetType)` backs the non-generic read
surface — `GetValue(ordinal)`, `this[ordinal]`, `GetValues(object[])`. It always
ran the boxed value through `Convert.ChangeType`, even when `targetType` already
matched the column's natural type. That is the common case, because those APIs
read using the column's `ClrType`.

`Convert.ChangeType` does **not** early-out on same-type for `IConvertible`
values: it dispatches through `ToXxx()` and re-boxes the result, so every value
was boxed twice. This adds a `value.GetType() == targetType` fast path that
returns the already-boxed value directly.

```csharp
// after building the boxed `value` from the column
if (value.GetType() == targetType)
{
    return value;
}

if (targetType.IsNumeric())
{
    // Convert.ChangeType (unchanged) …
}
```

## Benchmark

Reading 1,000,000 rows × 3 numeric columns (`INTEGER, BIGINT, DOUBLE`) via
`GetValue(ordinal)`. BenchmarkDotNet, .NET 10, Apple M4 Pro:

| `GetValue` path | Before | After | Change |
|---|---:|---:|---:|
| Mean time | 54.50 ms | 22.73 ms | **−58%** |
| Allocated | 137.3 MB | 68.7 MB | **−50%** |

The typed `GetFieldValue<T>` path is unaffected (~16 ms baseline). The remaining
~69 MB is the unavoidable single box of the `object`-returning API.

## Correctness

Behavior is unchanged: for same-type, `ChangeType` returned the same value
anyway, and `BigInteger` (which is not `IConvertible`) already hit this exact
early-out inside `ChangeType`. Full existing suite passes locally (6,895 tests).

---

Third in a small series of allocation-focused changes (#336, #337). Source-only;
the benchmark harness is the `DuckDB.NET.Benchmarks` project from #336.
