### PR TITLE
Reduce allocations when materializing MAP values

### DIFF
--- a/DuckDB.NET.Data/DataChunk/Reader/MapVectorDataReader.cs
+++ b/DuckDB.NET.Data/DataChunk/Reader/MapVectorDataReader.cs
@@ -1,9 +1,15 @@
-﻿namespace DuckDB.NET.Data.DataChunk.Reader;
+﻿using System.Collections.Concurrent;
+
+namespace DuckDB.NET.Data.DataChunk.Reader;
 
 internal sealed class MapVectorDataReader : VectorDataReaderBase
 {
+    private static readonly ConcurrentDictionary<Type, IMapMaterializer> Materializers = new();
+
     private readonly VectorDataReaderBase keyReader;
     private readonly VectorDataReaderBase valueReader;
+    private Type? cachedTargetType;
+    private IMapMaterializer? cachedMaterializer;
 
     internal unsafe MapVectorDataReader(IntPtr vector, void* dataPointer, ulong* validityMaskPointer, DuckDBType columnType, DuckDBLogicalType logicalColumnType, string columnName) 
                     : base(dataPointer, validityMaskPointer, columnType, columnName)
@@ -37,16 +43,21 @@ internal sealed class MapVectorDataReader : VectorDataReaderBase
             return base.GetValue(offset, targetType);
         }
 
+        var listData = (DuckDBListEntry*)DataPointer + offset;
+        var materializer = GetMaterializer(targetType);
+
+        if (materializer != null)
+        {
+            return materializer.Materialize(keyReader, valueReader, listData->Offset, listData->Length, ColumnName);
+        }
+
         if (Activator.CreateInstance(targetType) is not IDictionary instance)
         {
             throw new InvalidOperationException($"Cannot read Map column {ColumnName} in a non-dictionary type");
         }
 
         var arguments = targetType.GetGenericArguments();
-
         var allowsNullValues = arguments.Length == 2 && arguments[1].AllowsNullValue(out _, out _);
-
-        var listData = (DuckDBListEntry*)DataPointer + offset;
 
         for (ulong i = 0; i < listData->Length; i++)
         {
@@ -68,6 +79,43 @@ internal sealed class MapVectorDataReader : VectorDataReaderBase
         return instance;
     }
 
+    private IMapMaterializer? GetMaterializer(Type targetType)
+    {
+        if (targetType == cachedTargetType)
+        {
+            return cachedMaterializer;
+        }
+
+        cachedTargetType = targetType;
+        cachedMaterializer = null;
+
+        if (!targetType.IsGenericType || targetType.GetGenericTypeDefinition() != typeof(Dictionary<,>))
+        {
+            return null;
+        }
+
+        var arguments = targetType.GetGenericArguments();
+        if (!CanReadDirectly(keyReader, arguments[0]) || !CanReadDirectly(valueReader, arguments[1]))
+        {
+            return null;
+        }
+
+        cachedMaterializer = Materializers.GetOrAdd(targetType, static type => CreateMaterializer(type));
+        return cachedMaterializer;
+    }
+
+    private static bool CanReadDirectly(VectorDataReaderBase reader, Type targetType)
+    {
+        var valueType = Nullable.GetUnderlyingType(targetType) ?? targetType;
+        return valueType == reader.ClrType || valueType == reader.ProviderSpecificClrType;
+    }
+
+    private static IMapMaterializer CreateMaterializer(Type targetType)
+    {
+        var materializerType = typeof(MapMaterializer<,>).MakeGenericType(targetType.GetGenericArguments());
+        return (IMapMaterializer)Activator.CreateInstance(materializerType)!;
+    }
+
     internal override void Reset(IntPtr vector)
     {
         base.Reset(vector);
@@ -83,5 +131,50 @@ internal sealed class MapVectorDataReader : VectorDataReaderBase
         keyReader.Dispose();
         valueReader.Dispose();
         base.Dispose();
+    }
+
+    private interface IMapMaterializer
+    {
+        object Materialize(VectorDataReaderBase keys, VectorDataReaderBase values, ulong offset, ulong length, string columnName);
+    }
+
+    private sealed class MapMaterializer<TKey, TValue> : IMapMaterializer where TKey : notnull
+    {
+        private static readonly bool AllowsNullValues = typeof(TValue).AllowsNullValue(out _, out _);
+
+        public object Materialize(VectorDataReaderBase keys, VectorDataReaderBase values, ulong offset, ulong length, string columnName)
+        {
+            var result = new Dictionary<TKey, TValue>(checked((int)length));
+
+            for (ulong i = 0; i < length; i++)
+            {
+                var childOffset = offset + i;
+                var key = Read<TKey>(keys, childOffset);
+
+                if (values.IsValid(childOffset))
+                {
+                    result.Add(key, Read<TValue>(values, childOffset));
+                }
+                else if (AllowsNullValues)
+                {
+                    result.Add(key, default!);
+                }
+                else
+                {
+                    throw new InvalidCastException($"The Map in column {columnName} contains null value but dictionary does not allow null values");
+                }
+            }
+
+            return result;
+        }
+
+        private static T Read<T>(VectorDataReaderBase reader, ulong offset)
+        {
+            // Object-valued readers need their natural non-generic path. Concrete value types use
+            // the generic path so they can flow into Dictionary<TKey, TValue> without boxing.
+            return typeof(T) == typeof(object)
+                ? (T)reader.GetValue(offset)
+                : reader.GetValueStrict<T>(offset);
+        }
     }
 }

--- a/DuckDB.NET.Test/DuckDBDataReaderMapTests.cs
+++ b/DuckDB.NET.Test/DuckDBDataReaderMapTests.cs
@@ -54,6 +54,32 @@ public class DuckDBDataReaderMapTests(DuckDBDatabaseFixture db) : DuckDBTestBase
     }
 
     [Fact]
+    public void ReadMapWithWiderValueTypeUsesCompatibleFallback()
+    {
+        Command.CommandText = "SELECT MAP { 'key1': 1, 'key2': 5, 'key3': 7 }";
+        var reader = Command.ExecuteReader();
+
+        reader.Read();
+        var value = reader.GetFieldValue<Dictionary<string, object>>(0);
+
+        var expectation = new Dictionary<string, object>() { { "key1", 1 }, { "key2", 5 }, { "key3", 7 } };
+        value.Should().BeEquivalentTo(expectation);
+    }
+
+    [Fact]
+    public void ReadMapIntoDerivedDictionaryUsesCompatibleFallback()
+    {
+        Command.CommandText = "SELECT MAP { 'key1': 1, 'key2': 5, 'key3': 7 }";
+        var reader = Command.ExecuteReader();
+
+        reader.Read();
+        var value = reader.GetFieldValue<CustomDictionary<string, int>>(0);
+
+        var expectation = new Dictionary<string, int>() { { "key1", 1 }, { "key2", 5 }, { "key3", 7 } };
+        value.Should().BeEquivalentTo(expectation);
+    }
+
+    [Fact]
     public void ReadMapWithNullInNullableDictionary()
     {
         Command.CommandText = "SELECT MAP { 'key1': 1, 'key2': NULL, 'key3': 7 }";
@@ -146,5 +172,9 @@ public class DuckDBDataReaderMapTests(DuckDBDatabaseFixture db) : DuckDBTestBase
         {
             return string.Join(",", obj).GetHashCode();
         }
+    }
+
+    private sealed class CustomDictionary<TKey, TValue> : Dictionary<TKey, TValue> where TKey : notnull
+    {
     }
 }


### PR DESCRIPTION
## What changed

MAP values currently go through `IDictionary`, which boxes numeric keys and values and lets `Dictionary` grow as entries are added.

This keeps that fallback for custom or wider dictionary targets, but adds a typed path for normal `Dictionary<TKey, TValue>` reads:

- cache one closed generic materializer per compatible dictionary type
- pre-size the dictionary from DuckDB's MAP length
- read keys and values through the generic vector readers
- cache the selected materializer on the vector reader instead of resolving it per row
- check compatibility before adding anything to the process-wide cache

Nullable values, provider-specific types, nested values, and derived/wider dictionaries keep the existing behavior.

## Benchmark

The benchmark materializes 100,000 rows of `Dictionary<int, int>`, with 16 entries per row:

```sql
SELECT map(range(16)::INTEGER[], range(16)::INTEGER[]) AS values
FROM range(100000)
```

Results are the median of 7 measured runs after warmup, using a Release build on the same machine.

| Metric | Before | After | Change | Winner |
| --- | ---: | ---: | ---: | --- |
| Median elapsed | 94.35 ms | 93.77 ms | -0.6% | No meaningful difference |
| Allocated | 151.07 MiB | 45.02 MiB | -70.2% | After |

The allocation reduction is the useful result here. The elapsed-time difference is small enough to treat as noise.

## Validation

- MAP reader tests: 11 passed
- cache probe: incompatible target remains uncached; compatible target is cached once
- `git diff --check` passes
- the full suite was also exercised; the MAP tests stay green, while repeated runs exposed an existing order-dependent UDF exception-store failure that passes when run alone
