### PR TITLE
Pre-size LIST results during materialization

### DIFF
--- a/DuckDB.NET.Data/DataChunk/Reader/ListVectorDataReader.cs
+++ b/DuckDB.NET.Data/DataChunk/Reader/ListVectorDataReader.cs
@@ -4,6 +4,8 @@ internal sealed class ListVectorDataReader : VectorDataReaderBase
 {
     private readonly ulong arraySize;
     private readonly VectorDataReaderBase listDataReader;
+    private Type? cachedListType;
+    private IListFactory? cachedListFactory;
 
     public bool IsList => DuckDBType == DuckDBType.List;
 
@@ -51,8 +53,7 @@ internal sealed class ListVectorDataReader : VectorDataReaderBase
 
         var allowNulls = listType.AllowsNullValue(out _, out var nullableType);
 
-        var list = Activator.CreateInstance(returnType) as IList
-                   ?? throw new ArgumentException($"The type '{returnType.Name}' specified in parameter {nameof(returnType)} cannot be instantiated as an IList.");
+        var list = CreateList(returnType, length);
 
         //Special case for specific types to avoid boxing
         return list switch
@@ -105,6 +106,31 @@ internal sealed class ListVectorDataReader : VectorDataReaderBase
         }
     }
 
+    private IList CreateList(Type returnType, ulong length)
+    {
+        if (returnType != cachedListType)
+        {
+            cachedListType = returnType;
+            cachedListFactory = returnType.IsGenericType && returnType.GetGenericTypeDefinition() == typeof(List<>)
+                ? CreateListFactory(returnType)
+                : null;
+        }
+
+        if (cachedListFactory != null)
+        {
+            return cachedListFactory.Create(checked((int)length));
+        }
+
+        return Activator.CreateInstance(returnType) as IList
+               ?? throw new ArgumentException($"The type '{returnType.Name}' specified in parameter {nameof(returnType)} cannot be instantiated as an IList.");
+    }
+
+    private static IListFactory CreateListFactory(Type returnType)
+    {
+        var factoryType = typeof(ListFactory<>).MakeGenericType(returnType.GetGenericArguments()[0]);
+        return (IListFactory)Activator.CreateInstance(factoryType)!;
+    }
+
     internal override void Reset(IntPtr vector)
     {
         base.Reset(vector);
@@ -118,5 +144,15 @@ internal sealed class ListVectorDataReader : VectorDataReaderBase
     {
         listDataReader.Dispose();
         base.Dispose();
+    }
+
+    private interface IListFactory
+    {
+        IList Create(int capacity);
+    }
+
+    private sealed class ListFactory<T> : IListFactory
+    {
+        public IList Create(int capacity) => new List<T>(capacity);
     }
 }

--- a/DuckDB.NET.Test/DuckDBDataReaderListTests.cs
+++ b/DuckDB.NET.Test/DuckDBDataReaderListTests.cs
@@ -3,6 +3,19 @@
 public class DuckDBDataReaderListTests(DuckDBDatabaseFixture db) : DuckDBTestBase(db)
 {
     [Fact]
+    public void PreSizesListResults()
+    {
+        Command.CommandText = "SELECT range(17)::INTEGER[];";
+        using var reader = Command.ExecuteReader();
+
+        reader.Read();
+        var list = reader.GetFieldValue<List<int>>(0);
+
+        list.Should().HaveCount(17);
+        list.Capacity.Should().Be(17);
+    }
+
+    [Fact]
     public void ReadListOfIntegers()
     {
         Command.CommandText = "SELECT [1, 2, 3];";


### PR DESCRIPTION
## Problem

LIST values are materialized into an empty `List<T>` and grown as each item is added. That creates avoidable backing-array allocations and repeats reflective construction for every row.

## Solution

Create normal `List<T>` results through a reader-local generic factory and pass DuckDB's known list length as the initial capacity. Custom collection targets keep the existing fallback.

## Benchmark

100,000 rows with a 16-item `List<int>`, median of 7 runs after warmup:

| Metric | Before | After | Change |
| --- | ---: | ---: | ---: |
| Elapsed | 95.20 ms | 68.58 ms | -28.0% |
| Allocated | 45.02 MiB | 14.50 MiB | -67.8% |

## Tests

- 74 LIST, nested LIST, ARRAY, and type-reader tests passed
- Full suite: 6,897 passed
